### PR TITLE
OPENNLP-1111: Improving for OpenNLP testingng on AWS.

### DIFF
--- a/aws-ec2-testing-scripts/README.md
+++ b/aws-ec2-testing-scripts/README.md
@@ -12,14 +12,16 @@ These scripts are written expecting the following directory structure:
 
 ## EC2 Instance Requirements
 
+The instance defined in the CloudFormation template `cf-template.json` satisfies these requirements. You can create a stack from the template either through the AWS Console or using the AWS CLI.
+
 * The instance must have the AWS CLI installed.
 * The scripts use SNS to send notifications so the instance must have permissions to publish SNS messages through either an instance role or via access/secret keys configured in the AWS CLI.
 * You must have an existing SNS topic configured to publish messages to and you must set the ARN in the `notify.sh` script.
 
 ## Notifications and Results
 
-You can configure the subject, message, and destination (topic ARN) in the `notify.sh` script. The build log will be too large (>256KB) for sending in the SNS message. You can modify the `notify.sh` script for uploading the build results to an S3 bucket.
+You can configure the subject, message, and destination (topic ARN) in the `notify.sh` script. The build log will be too large (>256KB) for sending in the SNS message so SSH into the instance to check the log.
 
-## CloudFormation Template
+## License
 
-The CloudFormation template can help with creating the instance.
+Licensed under the Apache Software License, version 2.

--- a/aws-ec2-testing-scripts/cf-template.json
+++ b/aws-ec2-testing-scripts/cf-template.json
@@ -1,11 +1,11 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "Stack for running OpenNLP testing.",
+  "Description": "Stack for running OpenNLP testing. Licensed under the ASLv2.",
   "Parameters": {
     "InstanceType": {
       "Description": "EC2 instance type.",
       "Type": "String",
-      "Default": "r4.xlarge"
+      "Default": "m4.xlarge"
     },
     "Image": {
       "Description": "The base AMI.",
@@ -16,6 +16,20 @@
       "Description": "An existing EC2 keypair.",
       "Type": "AWS::EC2::KeyPair::KeyName",
       "ConstraintDescription": "Must be the name of an existing EC2 keypair."
+    },
+    "OpenNLPDataOnS3": {
+      "Description": "The location of the OpenNLP evaluation test data on S3.",
+      "Type": "String",
+      "ConstraintDescription": "s3://bucket-name/opennlp-data.zip"
+    },
+    "NotificationsEmail": {
+      "Description": "Email address to receive notifications.",
+      "Type": "String"
+    },
+    "SSHCIDR": {
+      "Description": "IP to allow SSH.",
+      "Type": "String",
+      "Default": "0.0.0.0/0"
     }
   },
   "Resources": {
@@ -23,6 +37,8 @@
       "Type": "AWS::EC2::VPC",
       "Properties": {
         "CidrBlock": "10.0.0.0/16",
+        "EnableDnsSupport": true,
+        "EnableDnsHostnames": true,
         "Tags": [
           {
             "Key": "Application",
@@ -36,10 +52,8 @@
     "Subnet": {
       "Type": "AWS::EC2::Subnet",
       "Properties": {
-        "VpcId": {
-          "Ref": "VPC"
-        },
         "CidrBlock": "10.0.0.0/24",
+        "MapPublicIpOnLaunch": true,
         "Tags": [
           {
             "Key": "Application",
@@ -47,7 +61,10 @@
               "Ref": "AWS::StackId"
             }
           }
-        ]
+        ],
+        "VpcId": {
+          "Ref": "VPC"
+        }
       }
     },
     "InternetGateway": {
@@ -114,43 +131,107 @@
         }
       }
     },
-    "NetworkAcl": {
-      "Type": "AWS::EC2::NetworkAcl",
-      "Properties": {
-        "VpcId": {
-          "Ref": "VPC"
-        },
-        "Tags": [
-          {
-            "Key": "Application",
-            "Value": {
-              "Ref": "AWS::StackId"
-            }
-          }
-        ]
-      }
-    },
     "InstanceSecurityGroup": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
-        "VpcId": {
-          "Ref": "VPC"
-        },
         "GroupDescription": "Enable SSH access via port 22",
         "SecurityGroupIngress": [
           {
             "IpProtocol": "tcp",
             "FromPort": "22",
             "ToPort": "22",
-            "CidrIp": "0.0.0.0/0"
+            "CidrIp": {
+              "Ref": "SSHCIDR"
+            }
+          }
+        ],
+        "VpcId": {
+          "Ref": "VPC"
+        }
+      }
+    },
+    "RolePolicies": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "root",
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": "s3:*",
+              "Resource": "*"
+            },
+            {
+              "Action": [
+                "sns:*"
+              ],
+              "Effect": "Allow",
+              "Resource": "*"
+            }
+          ]
+        },
+        "Roles": [
+          {
+            "Ref": "InstanceRole"
           }
         ]
+      }
+    },
+    "InstanceRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "ec2.amazonaws.com"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRole"
+              ]
+            }
+          ]
+        },
+        "Path": "/"
+      }
+    },
+    "InstanceProfile": {
+      "Type": "AWS::IAM::InstanceProfile",
+      "Properties": {
+        "Path": "/",
+        "Roles": [
+          {
+            "Ref": "InstanceRole"
+          }
+        ]
+      }
+    },
+    "SNSTopic": {
+      "Type": "AWS::SNS::Topic",
+      "Properties": {
+        "Subscription": [
+          {
+            "Endpoint": {
+              "Ref": "NotificationsEmail"
+            },
+            "Protocol": "email"
+          }
+        ],
+        "TopicName": "OpenNLP-Notification"
       }
     },
     "OpenNLPInstance": {
       "Type": "AWS::EC2::Instance",
       "DependsOn": "AttachGateway",
       "Properties": {
+        "IamInstanceProfile": {
+          "Ref": "InstanceProfile"
+        },
         "ImageId": {
           "Ref": "Image"
         },
@@ -159,6 +240,14 @@
         },
         "KeyName": {
           "Ref": "KeyName"
+        },
+        "SecurityGroupIds": [
+          {
+            "Ref": "InstanceSecurityGroup"
+          }
+        ],
+        "SubnetId": {
+          "Ref": "Subnet"
         },
         "Tags": [
           {
@@ -186,8 +275,13 @@
                 "# Get OpenNLP\n",
                 "git clone https://github.com/apache/opennlp.git\n",
                 "mv opennlp /opt/\n",
+                "sed -i 's/TOPICARNPARAM/", {"Ref": "SNSTopic"}, "/g' /opt/notify.sh\n",
                 "mkdir /opt/opennlp-data\n",
-                "aws s3 cp s3://bucket/opennlp-data /opt/opennlp-data --recursive\n"
+                "aws s3 cp ",
+                {
+                  "Ref": "OpenNLPDataOnS3"
+                },
+                " /opt/opennlp-data --recursive\n"
               ]
             ]
           }
@@ -195,5 +289,15 @@
       }
     }
   },
-  "Outputs": {}
+  "Outputs": {
+    "Instance": {
+      "Description": "The instance public IP.",
+      "Value": {
+        "Fn::GetAtt": [
+          "OpenNLPInstance",
+          "PublicDnsName"
+        ]
+      }
+    }
+  }
 }

--- a/aws-ec2-testing-scripts/notify.sh
+++ b/aws-ec2-testing-scripts/notify.sh
@@ -18,11 +18,8 @@
 # Configure these values as desired.
 
 # Notifications via SNS.
-TOPIC_ARN="arn:aws:sns:us-east-1:XXXXXXXXXXXX:opennlp-notification"
+TOPIC_ARN="TOPICARNPARAM"
 SUBJECT="OpenNLP Notification"
-
-# Upload of build output to S3. (Uncomment below to enable.)
-BUCKET=""
 
 # Received from the training scripts.
 MESSAGE=$1
@@ -30,7 +27,3 @@ ACTION=$2
 
 # Publish the message to SNS.
 aws sns publish --topic-arn "$TOPIC_ARN" --message "$MESSAGE" --subject "$SUBJECT"
-
-# Upload the build output to S3.
-TIMESTAMP=`date +"%T"`
-#aws s3 cp nohup.out s3://$BUCKET/$2-output-$TIMESTAMP.txt


### PR DESCRIPTION
- Adds IAM policies for S3 and SNS.
- Adds outputs.
- Parameterize SSH CIDR and notifications email to be used later by `notify.sh`.
- Parameterizes the location of the test data on S3.