### PR TITLE
Bug fixes, wrap FileWriter with BufferedWriter

### DIFF
--- a/modelbuilder-addon/src/main/java/opennlp/addons/modelbuilder/impls/GenericModelableImpl.java
+++ b/modelbuilder-addon/src/main/java/opennlp/addons/modelbuilder/impls/GenericModelableImpl.java
@@ -18,6 +18,7 @@ package opennlp.addons.modelbuilder.impls;
 import java.io.BufferedOutputStream;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -57,7 +58,7 @@ public class GenericModelableImpl implements Modelable {
   public void writeAnnotatedSentences() {
     try {
 
-      FileWriter writer = new FileWriter(params.getAnnotatedTrainingDataFile(), false);
+      BufferedWriter writer = new BufferedWriter(new FileWriter(params.getAnnotatedTrainingDataFile(), false));
 
       for (String s : annotatedSentences) {
         writer.write(s.replace("\n", " ").trim() + "\n");

--- a/opennlp-coref/src/main/java/opennlp/tools/coref/resolver/DefaultNonReferentialResolver.java
+++ b/opennlp-coref/src/main/java/opennlp/tools/coref/resolver/DefaultNonReferentialResolver.java
@@ -19,6 +19,7 @@ package opennlp.tools.coref.resolver;
 
 import java.io.DataInputStream;
 import java.io.File;
+import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -119,7 +120,7 @@ public class DefaultNonReferentialResolver implements NonReferentialResolver {
     if (ResolverMode.TRAIN == mode) {
       System.err.println(this + " referential");
       if (debugOn) {
-        FileWriter writer = new FileWriter(modelName + ".events");
+        BufferedWriter writer = new BufferedWriter(new FileWriter(modelName + ".events"));
         for (Iterator<Event> ei = events.iterator(); ei.hasNext();) {
           Event e = ei.next();
           writer.write(e.toString() + "\n");

--- a/opennlp-coref/src/main/java/opennlp/tools/coref/resolver/MaxentResolver.java
+++ b/opennlp-coref/src/main/java/opennlp/tools/coref/resolver/MaxentResolver.java
@@ -18,6 +18,7 @@
 package opennlp.tools.coref.resolver;
 
 import java.io.File;
+import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -332,7 +333,7 @@ public abstract class MaxentResolver extends AbstractResolver {
     if (ResolverMode.TRAIN == mode) {
       if (debugOn) {
         System.err.println(this + " referential");
-        FileWriter writer = new FileWriter(modelName + ".events");
+        BufferedWriter writer = new BufferedWriter(new FileWriter(modelName + ".events"));
         for (Iterator<Event> ei = events.iterator(); ei.hasNext();) {
           Event e = ei.next();
           writer.write(e.toString() + "\n");

--- a/opennlp-coref/src/main/java/opennlp/tools/coref/sim/GenderModel.java
+++ b/opennlp-coref/src/main/java/opennlp/tools/coref/sim/GenderModel.java
@@ -21,6 +21,7 @@ package opennlp.tools.coref.sim;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
+import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -269,7 +270,7 @@ public class GenderModel implements TestGenderModel, TrainSimilarityModel {
 
   public void trainModel() throws IOException {
     if (debugOn) {
-      FileWriter writer = new FileWriter(modelName + ".events");
+      BufferedWriter writer = new BufferedWriter(new FileWriter(modelName + ".events"));
       for (Iterator<Event> ei = events.iterator();ei.hasNext();) {
         Event e = ei.next();
         writer.write(e.toString() + "\n");

--- a/opennlp-coref/src/main/java/opennlp/tools/coref/sim/SimilarityModel.java
+++ b/opennlp-coref/src/main/java/opennlp/tools/coref/sim/SimilarityModel.java
@@ -19,6 +19,7 @@ package opennlp.tools.coref.sim;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -366,7 +367,7 @@ public class SimilarityModel implements TestSimilarityModel, TrainSimilarityMode
    */
   public void trainModel() throws IOException {
     if (debugOn) {
-      FileWriter writer = new FileWriter(modelName + ".events");
+      BufferedWriter writer = new BufferedWriter(new FileWriter(modelName + ".events"));
       for (Iterator<Event> ei = events.iterator();ei.hasNext();) {
         Event e = ei.next();
         writer.write(e.toString() + "\n");


### PR DESCRIPTION
Bug fixes. When a FileWriter is intensively used in a loop, it should be wrapped by BufferedWriter to gain a good performance. Usually, the IO operations can be the performance bottleneck of program, to avoid frequent IO operations, the BufferedWriter is highly recommended.