### PR TITLE
OPENNLP-1259 - Replace instances of Math.random with Random.nextDouble

### DIFF
--- a/nlp-utils/src/main/java/org/apache/opennlp/utils/regression/GradientDescentUtils.java
+++ b/nlp-utils/src/main/java/org/apache/opennlp/utils/regression/GradientDescentUtils.java
@@ -19,6 +19,7 @@
 package org.apache.opennlp.utils.regression;
 
 import java.util.Arrays;
+import java.util.Random;
 import org.apache.opennlp.utils.TrainingSet;
 
 /**
@@ -71,7 +72,8 @@ public class GradientDescentUtils {
   private static double[] initializeRandomWeights(int size) {
     double[] doubles = new double[size];
     for (int i = 0; i < doubles.length; i++) {
-      doubles[i] = Math.random() * 0.1d;
+      Random rand = new Random();
+      doubles[i] = rand.nextDouble() * 0.1d;
     }
     return doubles;
   }

--- a/opennlp-similarity/src/main/java/opennlp/tools/apps/relevanceVocabs/SynonymListFilter.java
+++ b/opennlp-similarity/src/main/java/opennlp/tools/apps/relevanceVocabs/SynonymListFilter.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -92,7 +93,8 @@ public class SynonymListFilter {
 			String[] synonyms = map.getSynonyms(word);
 			if (synonyms==null || synonyms.length<1)
 				return null;
-			int index = (int) Math.floor(Math.random()*(double)synonyms.length);
+			Random rand = new Random();
+			int index = (int) Math.floor(rand.nextDouble()*(double)synonyms.length);
 			System.out.println("Found synonyms "+Arrays.asList(synonyms).toString()+ " | selected synonym = "+synonyms[index] +" | for the input = "+ word);
 			return synonyms[index];
 			

--- a/opennlp-similarity/src/main/java/opennlp/tools/apps/review_builder/SentenceOriginalizer.java
+++ b/opennlp-similarity/src/main/java/opennlp/tools/apps/review_builder/SentenceOriginalizer.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Random;
 
 import org.apache.commons.lang.StringUtils;
 
@@ -87,7 +88,8 @@ public class SentenceOriginalizer {
 		prodName = StringUtils.trim(prodName.toLowerCase());
 				
 		for(int i = 0; i< sents.length; i++){
-			double flag = Math.random();
+			Random rand = new Random();
+			double flag = rand.nextDouble();
 			String prodNameCurr = null;
 			if (flag>0.4)
 				prodNameCurr = prodName;

--- a/opennlp-similarity/src/main/java/opennlp/tools/textsimilarity/ParseTreeMatcher.java
+++ b/opennlp-similarity/src/main/java/opennlp/tools/textsimilarity/ParseTreeMatcher.java
@@ -20,6 +20,7 @@ package opennlp.tools.textsimilarity;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Random;
 
 public class ParseTreeMatcher {
 
@@ -151,6 +152,7 @@ public class ParseTreeMatcher {
         String sim = posManager.similarPOS(pos1.get(k1), pos2.get(k2));
         String lemmaMatch = lemmaFormManager.matchLemmas(null, chunk1
             .getLemmas().get(k1), chunk2.getLemmas().get(k2), sim);
+	Random rand = new Random();
         // if (LemmaFormManager.acceptableLemmaAndPOS(sim, lemmaMatch)){
         if ((sim != null)
             && (lemmaMatch == null || (lemmaMatch != null && !lemmaMatch
@@ -168,7 +170,7 @@ public class ParseTreeMatcher {
           }
           k1++;
           k2++;
-        } else if (Math.random() > 0.5) {
+        } else if (rand.nextDouble() > 0.5) {
           k1++;
         } else {
           k2++;


### PR DESCRIPTION
[OPENNLP-1259](https://issues.apache.org/jira/browse/OPENNLP-1259) When compared to Random.nextDouble, there is a slight performance overhead associated with Math.random. Switching to Random.nextDouble can reduce this overhead and offers more control over the randomness in the future.