### PR TITLE
TF_NER_POC: Fix writing order of labels, tokens and chars

### DIFF
--- a/tf-ner-poc/src/main/python/namefinder/namefinder.py
+++ b/tf-ner-poc/src/main/python/namefinder/namefinder.py
@@ -322,7 +322,7 @@ def get_chunks(seq, tags):
 
 def write_mapping(tags, output_filename):
     with open(output_filename, 'w', encoding='utf-8') as f:
-        for i, tag in enumerate(tags):
+        for (tag, i) in sorted(tags.items(), key=lambda x: x[1]):
             f.write('{}\n'.format(tag))
 
 def load_glove(glove_file):


### PR DESCRIPTION
labels, tokens and chars were not written in correct order to the files when saving the model.