### PR TITLE
Update sandbox component 'tagging-server' to be compatible with latest opennlp-tools release

### DIFF
--- a/tagging-server/pom.xml
+++ b/tagging-server/pom.xml
@@ -21,59 +21,50 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-
 	<parent>
 		<groupId>org.apache</groupId>
 		<artifactId>apache</artifactId>
-		<version>9</version>
+		<!-- TODO OPENNLP-1452 once this is resolved, move to 29 as well. -->
+		<version>18</version>
 		<relativePath />
 	</parent>
 
 	<groupId>org.apache.opennlp</groupId>
 	<artifactId>tagging-server</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
-	<name>OpenNLP Tagging Server</name>
+	<name>Apache OpenNLP Tagging Server</name>
 
 	<prerequisites>
 		<maven>3.0</maven>
 	</prerequisites>
-
-	<repositories>
-		<repository>
-		    <id>maven2-repository.java.net</id>
-		    <name>Java.net Repository for Maven</name>
-		    <url>http://download.java.net/maven/2/</url>
-		    <layout>default</layout>
-		</repository>
-	</repositories>
 	
 	<dependencies>
 	
 		<dependency>
 		  <groupId>org.apache.opennlp</groupId>
 		  <artifactId>opennlp-tools</artifactId>
-		  <version>1.5.2-incubating</version>
+		  <version>2.1.0</version>
 		</dependency>
 		
-	    <dependency>
-      		<groupId>javax.servlet</groupId>
-      		<artifactId>servlet-api</artifactId>
-      		<version>2.5</version>
-    	</dependency>
-    
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
-            <version>4.2.0</version>
-        </dependency>
-        
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.compendium</artifactId>
-            <version>4.2.0</version>
-        </dependency>
+		<dependency>
+				<groupId>javax.servlet</groupId>
+				<artifactId>servlet-api</artifactId>
+				<version>2.5</version>
+		</dependency>
+
+		<dependency>
+				<groupId>org.osgi</groupId>
+				<artifactId>org.osgi.core</artifactId>
+				<version>4.2.0</version>
+		</dependency>
+
+		<dependency>
+				<groupId>org.osgi</groupId>
+				<artifactId>org.osgi.compendium</artifactId>
+				<version>4.2.0</version>
+		</dependency>
 
 		<dependency>
 			<groupId>com.sun.jersey</groupId>
@@ -97,7 +88,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.8.1</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -108,66 +99,68 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-          			<compilerArgument>-Xlint</compilerArgument>
+					<source>11</source>
+					<target>11</target>
+					<compilerArgument>-Xlint</compilerArgument>
 				</configuration>
 			</plugin>
 			
 			<!-- to generate the MANIFEST-FILE required by the bundle -->
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.7</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <id>bundle-manifest</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>manifest</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <manifestLocation>${project.build.directory}/META-INF</manifestLocation>
-                    <instructions>
-                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Import-Package>
-                        	!javax.persistence.*,
-                        	!javax.servlet.annotation,
-                        	!javax.servlet.jsp.*,
-                        	!javax.microedition.*,
-                        	!javax.mail.*,
-                        	!javax.transaction.xa,
-                        	!javax.jms,
-                        	!javax.interceptor,!javax.inject,
-                        	!javax.enterprise.*,
-                        	!javax.annotation.security,
-                        	!javax.ejb,
-                        	!com.sun.xml.fastinfoset.*,
-                        	!org.jvnet.*,
-                        	!org.apache.derby.impl.drda,
-                        	!com.ibm.jvm,
-                        	!com.sun.jdmk.comm,
-                        	!com.sun.net.httpserver,
-                        	!sun.misc,
-                        	javax.servlet,
-                        	*,
-                        	com.sun.jersey.json.impl.provider.entity.*,
-                        	com.sun.jersey.json.*,
-                        	org.codehaus.jackson.*,
-                        	org.codehaus.jackson.xc,
-                        	com.sun.jersey.api.core,
-                        	com.sun.jersey.spi.container.servlet</Import-Package>
-                        <!-- Import-Package>!com.ibm.jvm,!com.sun.jdmk.comm,!com.sun.net.httpserver,*,com.sun.jersey.api.core,com.sun.jersey.spi.container.servlet</Import-Package-->
-                        <Export-Package>org.apache.opennlp.tagging_server.*</Export-Package>
-                        <Webapp-Context>rest</Webapp-Context>
-                        <Web-ContextPath>rest</Web-ContextPath>
-                        <Bundle-Activator>org.apache.opennlp.tagging_server.TaggingServerBundle</Bundle-Activator>
-                    </instructions>
-                </configuration>
-            </plugin>
-	      </plugins>
+			<plugin>
+					<groupId>org.apache.felix</groupId>
+					<artifactId>maven-bundle-plugin</artifactId>
+					<version>5.1.8</version>
+					<extensions>true</extensions>
+					<executions>
+							<execution>
+									<id>bundle-manifest</id>
+									<phase>process-classes</phase>
+									<goals>
+											<goal>manifest</goal>
+									</goals>
+							</execution>
+					</executions>
+					<configuration>
+							<manifestLocation>${project.build.directory}/META-INF</manifestLocation>
+							<instructions>
+									<Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+									<Import-Package>
+										!javax.persistence.*,
+										!javax.servlet.annotation,
+										!javax.servlet.jsp.*,
+										!javax.microedition.*,
+										!javax.mail.*,
+										!javax.transaction.xa,
+										!javax.jms,
+										!javax.interceptor,
+										!javax.inject,
+										!javax.enterprise.*,
+										!javax.annotation.security,
+										!javax.ejb,
+										!com.sun.xml.fastinfoset.*,
+										!org.jvnet.*,
+										!org.apache.derby.impl.drda,
+										!com.ibm.jvm,
+										!com.sun.jdmk.comm,
+										!com.sun.net.httpserver,
+										!sun.misc,
+										javax.servlet,
+										*,
+										com.sun.jersey.json.impl.provider.entity.*,
+										com.sun.jersey.json.*,
+										org.codehaus.jackson.*,
+										org.codehaus.jackson.xc,
+										com.sun.jersey.api.core,
+										com.sun.jersey.spi.container.servlet
+									</Import-Package>
+									<!-- Import-Package>!com.ibm.jvm,!com.sun.jdmk.comm,!com.sun.net.httpserver,*,com.sun.jersey.api.core,com.sun.jersey.spi.container.servlet</Import-Package-->
+									<Export-Package>org.apache.opennlp.tagging_server.*</Export-Package>
+									<Webapp-Context>rest</Webapp-Context>
+									<Web-ContextPath>rest</Web-ContextPath>
+									<Bundle-Activator>org.apache.opennlp.tagging_server.TaggingServerBundle</Bundle-Activator>
+						</instructions>
+				</configuration>
+			</plugin>
+		</plugins>
 	</build>
 </project>

--- a/tagging-server/src/main/java/org/apache/opennlp/tagging_server/POSTaggerResource.java
+++ b/tagging-server/src/main/java/org/apache/opennlp/tagging_server/POSTaggerResource.java
@@ -40,7 +40,7 @@ public class POSTaggerResource {
   // @QueryParam("model") String modelName
   public String[][] tag(String document[][]) {
     
-    ServiceReference modelService = ModelUtil.getModelService(POSModel.class);
+    ServiceReference modelService = ModelUtil.getService(POSModel.class);
     
     try {
       String[][] tags = new String[document.length][];
@@ -53,7 +53,7 @@ public class POSTaggerResource {
       return tags;
     }
     finally {
-      ModelUtil.releaseModel(modelService);
+      ModelUtil.releaseService(modelService);
     }
   }
 }

--- a/tagging-server/src/main/java/org/apache/opennlp/tagging_server/ServiceUtil.java
+++ b/tagging-server/src/main/java/org/apache/opennlp/tagging_server/ServiceUtil.java
@@ -27,9 +27,6 @@ public class ServiceUtil {
 
   private ServiceUtil() {
   }
-  
-  
-  
 
   public static ServiceReference getModelServiceReference(
       Class<?> serviceClazz, String modelName) {
@@ -41,8 +38,7 @@ public class ServiceUtil {
 
     ServiceReference[] serviceReferences;
     try {
-      serviceReferences = context.getServiceReferences(
-          null, filter);
+      serviceReferences = context.getServiceReferences(null, filter);
     } catch (InvalidSyntaxException e) {
       throw new IllegalArgumentException("modelName can't be used as value in filter!", e);
     }

--- a/tagging-server/src/main/java/org/apache/opennlp/tagging_server/TaggingServerApplication.java
+++ b/tagging-server/src/main/java/org/apache/opennlp/tagging_server/TaggingServerApplication.java
@@ -30,7 +30,7 @@ public class TaggingServerApplication extends Application {
   
   @Override
   public Set<Class<?>> getClasses() {
-    Set<Class<?>> result = new HashSet<Class<?>>();
+    Set<Class<?>> result = new HashSet<>();
     result.add(POSTaggerResource.class);
     result.add(NameFinderResource.class);
     result.add(BratNameFinderResource.class);

--- a/tagging-server/src/main/java/org/apache/opennlp/tagging_server/TaggingServerBundle.java
+++ b/tagging-server/src/main/java/org/apache/opennlp/tagging_server/TaggingServerBundle.java
@@ -57,9 +57,7 @@ public class TaggingServerBundle implements BundleActivator {
         try {
           httpService.registerServlet("/rest", new ServletContainer(), jerseyServletParams, null);
           httpService.registerResources("/","/htmls",null);
-        } catch (ServletException e) {
-          throw new RuntimeException(e);
-        } catch (NamespaceException e) {
+        } catch (ServletException | NamespaceException e) {
           throw new RuntimeException(e);
         }
         

--- a/tagging-server/src/main/java/org/apache/opennlp/tagging_server/namefind/BratNameFinderResource.java
+++ b/tagging-server/src/main/java/org/apache/opennlp/tagging_server/namefind/BratNameFinderResource.java
@@ -12,13 +12,13 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+import org.apache.opennlp.tagging_server.ServiceUtil;
+import org.osgi.framework.ServiceReference;
+
 import opennlp.tools.namefind.TokenNameFinder;
 import opennlp.tools.sentdetect.SentenceDetector;
 import opennlp.tools.tokenize.Tokenizer;
 import opennlp.tools.util.Span;
-
-import org.apache.opennlp.tagging_server.ServiceUtil;
-import org.osgi.framework.ServiceReference;
 
 @Path("/bratner")
 public class BratNameFinderResource {
@@ -55,35 +55,35 @@ public class BratNameFinderResource {
 
       SentenceDetector sentDetect = nameFinderFactory.createSentenceDetector();
       Tokenizer tokenizer = nameFinderFactory.createTokenizer();
-      TokenNameFinder nameFinders[] = nameFinderFactory.createNameFinders();
+      TokenNameFinder[] nameFinders = nameFinderFactory.createNameFinders();
 
-      Span sentenceSpans[] = sentDetect.sentPosDetect(text);
+      Span[] sentenceSpans = sentDetect.sentPosDetect(text);
 
-      Map<String, NameAnn> map = new HashMap<String, NameAnn>();
+      Map<String, NameAnn> map = new HashMap<>();
 
       int indexCounter = 0;
 
-      for (int i = 0; i < sentenceSpans.length; i++) {
+      for (Span sentenceSpan : sentenceSpans) {
         // offset of sentence gets lost here!
-        Span tokenSpans[] = tokenizer.tokenizePos(sentenceSpans[i]
-            .getCoveredText(text).toString());
+        Span[] tokenSpans = tokenizer.tokenizePos(sentenceSpan
+                .getCoveredText(text).toString());
 
-        String tokens[] = Span.spansToStrings(tokenSpans, text);
-        
+        String[] tokens = Span.spansToStrings(tokenSpans, text);
+
         for (TokenNameFinder nameFinder : nameFinders) {
-          Span names[] = nameFinder.find(tokens);
+          Span[] names = nameFinder.find(tokens);
 
           for (Span name : names) {
             int beginOffset = tokenSpans[name.getStart()].getStart()
-                + sentenceSpans[i].getStart();
+                    + sentenceSpan.getStart();
             int endOffset = tokenSpans[name.getEnd() - 1].getEnd()
-                + sentenceSpans[i].getStart();
+                    + sentenceSpan.getStart();
 
             // create a list of new line indexes
             List<Integer> newLineIndexes = new ArrayList<Integer>();
-            
+
             // TODO: Code needs to handle case that there are multiple new lines in a row
-            
+
             boolean inNewLineSequence = false;
             for (int ci = beginOffset; ci < endOffset; ci++) {
               if (text.charAt(ci) == '\n' || text.charAt(ci) == '\r') {
@@ -91,40 +91,39 @@ public class BratNameFinderResource {
                   newLineIndexes.add(ci);
                 }
                 inNewLineSequence = true;
-              }
-              else {
+              } else {
                 inNewLineSequence = false;
               }
             }
-            
-            List<String> textSegments = new ArrayList<String>();
-            List<int[]> spanSegments = new ArrayList<int[]>();
-            
+
+            List<String> textSegments = new ArrayList<>();
+            List<int[]> spanSegments = new ArrayList<>();
+
             int segmentBegin = beginOffset;
-            
+
             for (int newLineOffset : newLineIndexes) {
               // create segment from begin to offset
               textSegments.add(text.substring(segmentBegin, newLineOffset));
               spanSegments.add(new int[]{segmentBegin, newLineOffset});
-              
+
               segmentBegin = findNextNonWhitespaceChar(text, newLineOffset + 1, endOffset);
-              
+
               if (segmentBegin == -1) {
                 break;
               }
             }
-            
+
             // create left over segment
             if (segmentBegin != -1) {
               textSegments.add(text.substring(segmentBegin, endOffset));
               spanSegments.add(new int[]{segmentBegin, endOffset});
             }
-            
+
             NameAnn ann = new NameAnn();
             ann.texts = textSegments.toArray(new String[textSegments.size()]);
             ann.offsets = spanSegments.toArray(new int[spanSegments.size()][]);
             ann.type = name.getType();
-            
+
             map.put(Integer.toString(indexCounter++), ann);
           }
         }

--- a/tagging-server/src/main/java/org/apache/opennlp/tagging_server/namefind/DefaultRawTextNameFinderFactory.java
+++ b/tagging-server/src/main/java/org/apache/opennlp/tagging_server/namefind/DefaultRawTextNameFinderFactory.java
@@ -31,12 +31,12 @@ public class DefaultRawTextNameFinderFactory implements RawTextNameFinderFactory
   
   private final SentenceModel sentModel;
   private final TokenizerModel tokenModel;
-  private final TokenNameFinderModel nameModels[];
+  private final TokenNameFinderModel[] nameModels;
 
   // TODO: How can this be an array of models with blueprint?!
   
   public DefaultRawTextNameFinderFactory(SentenceModel sentModel,
-      TokenizerModel tokenModel, TokenNameFinderModel nameModels[]) {
+      TokenizerModel tokenModel, TokenNameFinderModel[] nameModels) {
     this.sentModel = sentModel;
     this.tokenModel = tokenModel;
     this.nameModels = nameModels;
@@ -55,7 +55,7 @@ public class DefaultRawTextNameFinderFactory implements RawTextNameFinderFactory
   @Override
   public TokenNameFinder[] createNameFinders() {
     
-    TokenNameFinder nameFinders[] = new TokenNameFinder[nameModels.length];
+    TokenNameFinder[] nameFinders = new TokenNameFinder[nameModels.length];
     
     for (int i = 0; i < nameFinders.length; i++) {
       nameFinders[i] = new NameFinderME(nameModels[i]);

--- a/tagging-server/src/main/java/org/apache/opennlp/tagging_server/namefind/RawTextNameFinderFactory.java
+++ b/tagging-server/src/main/java/org/apache/opennlp/tagging_server/namefind/RawTextNameFinderFactory.java
@@ -27,6 +27,9 @@ import opennlp.tools.tokenize.Tokenizer;
  */
 public interface RawTextNameFinderFactory {
   SentenceDetector createSentenceDetector();
+
   Tokenizer createTokenizer();
+
   TokenNameFinder[] createNameFinders();
+  
 }

--- a/tagging-server/src/main/java/org/apache/opennlp/tagging_server/postag/POSTaggerResource.java
+++ b/tagging-server/src/main/java/org/apache/opennlp/tagging_server/postag/POSTaggerResource.java
@@ -23,12 +23,12 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import org.apache.opennlp.tagging_server.ServiceUtil;
+import org.osgi.framework.ServiceReference;
+
 import opennlp.tools.postag.POSModel;
 import opennlp.tools.postag.POSTagger;
 import opennlp.tools.postag.POSTaggerME;
-
-import org.apache.opennlp.tagging_server.ServiceUtil;
-import org.osgi.framework.ServiceReference;
 
 @Path("/postagger")
 public class POSTaggerResource {
@@ -39,7 +39,7 @@ public class POSTaggerResource {
   @Path("_tag")
   // @QueryParam("lang") String lang,
   // @QueryParam("model") String modelName
-  public String[][] tag(String document[][]) {
+  public String[][] tag(String[][] document) {
     
     ServiceReference modelService = ServiceUtil.getServiceReference(POSModel.class);
     

--- a/tagging-server/src/main/java/org/apache/opennlp/tagging_server/sentdetect/SentenceDetectorResource.java
+++ b/tagging-server/src/main/java/org/apache/opennlp/tagging_server/sentdetect/SentenceDetectorResource.java
@@ -26,13 +26,13 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import org.apache.opennlp.tagging_server.ServiceUtil;
+import org.osgi.framework.ServiceReference;
+
 import opennlp.tools.sentdetect.SentenceDetector;
 import opennlp.tools.sentdetect.SentenceDetectorME;
 import opennlp.tools.sentdetect.SentenceModel;
 import opennlp.tools.util.Span;
-
-import org.apache.opennlp.tagging_server.ServiceUtil;
-import org.osgi.framework.ServiceReference;
 
 @Path("/sentdetect")
 public class SentenceDetectorResource {

--- a/tagging-server/src/main/java/org/apache/opennlp/tagging_server/tokenize/TokenizerResource.java
+++ b/tagging-server/src/main/java/org/apache/opennlp/tagging_server/tokenize/TokenizerResource.java
@@ -26,12 +26,12 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import org.apache.opennlp.tagging_server.ServiceUtil;
+import org.osgi.framework.ServiceReference;
+
 import opennlp.tools.tokenize.TokenizerME;
 import opennlp.tools.tokenize.TokenizerModel;
 import opennlp.tools.util.Span;
-
-import org.apache.opennlp.tagging_server.ServiceUtil;
-import org.osgi.framework.ServiceReference;
 
 @Path("/tokenize")
 public class TokenizerResource {
@@ -47,7 +47,7 @@ public class TokenizerResource {
       TokenizerME tokenizer = new TokenizerME(
           ServiceUtil.getService(modelService, TokenizerModel.class));
       
-      List<String[]> tokenizedSentences = new ArrayList<String[]>();
+      List<String[]> tokenizedSentences = new ArrayList<>();
       
       for (String sentence : document) {
         tokenizedSentences.add(tokenizer.tokenize(sentence));
@@ -71,7 +71,7 @@ public class TokenizerResource {
       TokenizerME tokenizer = new TokenizerME(
               ServiceUtil.getService(modelService, TokenizerModel.class));
 
-      List<Span[]> tokenizedSentences = new ArrayList<Span[]>();
+      List<Span[]> tokenizedSentences = new ArrayList<>();
       
       for (String sentence : document) {
         tokenizedSentences.add(tokenizer.tokenizePos(sentence));


### PR DESCRIPTION
- adjusts opennlp-tools to 2.1.0
- adjusts parent project (org.apache.apache) to version 18
- adjusts Java language level to 11
- updates `maven-bundle-plugin` to version 5.1.8 so things work with class files compiled in Java 11 format
- adjusts some array declarations to comply with Java, not C style
- removes unused imports