### PR TITLE
Update sandbox component 'wikinews-importer' to be compatible with latest opennlp-tools release

### DIFF
--- a/wikinews-importer/pom.xml
+++ b/wikinews-importer/pom.xml
@@ -21,75 +21,55 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-
 	<parent>
 		<groupId>org.apache</groupId>
 		<artifactId>apache</artifactId>
-		<version>9</version>
+		<!-- TODO OPENNLP-1452 once this is resolved, move to 29 as well. -->
+		<version>18</version>
 		<relativePath />
 	</parent>
 
 	<groupId>org.apache.opennlp</groupId>
 	<artifactId>wikinews-importer</artifactId>
-	<version>0.0.1-incubating-SNAPSHOT</version>
+	<version>2.1.1-incubating-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
-	<name>OpenNLP Wikinews Importer</name>
+	<name>Apache OpenNLP Wikinews Importer</name>
 
-	<prerequisites>
-		<maven>3.0</maven>
-	</prerequisites>
+	<properties>
+		<uimaj.version>3.3.1</uimaj.version>
+	</properties>
 
-	<repositories>
-		<repository>
-			<id>maven2-repository.java.net</id>
-			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
-			<layout>default</layout>
-		</repository>
-
-		<repository>
-			<id>info-bliki-repository</id>
-			<url>http://gwtwiki.googlecode.com/svn/maven-repository/</url>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-	</repositories>
-	
 	<dependencies>
 		<dependency>
 		    <groupId>com.sun.jersey</groupId>
 		    <artifactId>jersey-json</artifactId>
-		    <version>1.8</version>
+		    <version>1.19.4</version>
 		</dependency>
 
 		<dependency>
 		    <groupId>com.sun.jersey</groupId>
 		    <artifactId>jersey-client</artifactId>
-		    <version>1.8</version>
+		    <version>1.19.4</version>
 		</dependency>
 
 	    <dependency> 
 	      <groupId>info.bliki.wiki</groupId> 
 	      <artifactId>bliki-core</artifactId> 
-	      <version>3.0.16</version> 
+	      <version>3.0.19</version>
 	    </dependency>
     
     	<dependency>
 			<groupId>org.apache.uima</groupId>
 			<artifactId>uimaj-core</artifactId>
-			<version>2.3.1</version>
+			<version>${uimaj.version}</version>
 			<scope>compile</scope>
 		</dependency>
 		
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.8.1</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -100,9 +80,9 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-          			<compilerArgument>-Xlint</compilerArgument>
+					<source>11</source>
+					<target>11</target>
+					<compilerArgument>-Xlint</compilerArgument>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/wikinews-importer/src/main/java/org/apache/opennlp/wikinews_importer/AnnotatingMarkupParser.java
+++ b/wikinews-importer/src/main/java/org/apache/opennlp/wikinews_importer/AnnotatingMarkupParser.java
@@ -17,6 +17,13 @@
 
 package org.apache.opennlp.wikinews_importer;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
 import info.bliki.htmlcleaner.ContentToken;
 import info.bliki.htmlcleaner.TagNode;
 import info.bliki.wiki.filter.ITextConverter;
@@ -28,24 +35,15 @@ import info.bliki.wiki.model.ImageFormat;
 import info.bliki.wiki.model.WikiModel;
 import info.bliki.wiki.tags.WPATag;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.regex.Pattern;
-
 /**
  * Parse mediawiki markup to strip the formatting info and extract a simple text
  * version suitable for NLP along with header, paragraph and link position
  * annotations.
- * 
+ * <p>
  * Use the {@code #convert(String)} and {@code #getWikiLinks()} methods.
- * 
- * Due to the constraints imposed by the {@code ITextConverter} /
- * {@code WikiModel} API, this class is not thread safe: only one instance
+ * <p>
+ * Due to the constraints imposed by the {@link ITextConverter} /
+ * {@link WikiModel} API, this class is not thread safe: only one instance
  * should be run by thread.
  */
 public class AnnotatingMarkupParser implements ITextConverter {
@@ -58,19 +56,17 @@ public class AnnotatingMarkupParser implements ITextConverter {
 
     public static final String WIKIOBJECT_ATTR_KEY = "wikiobject";
 
-    public static final Set<String> PARAGRAPH_TAGS = new HashSet<String>(
-            Arrays.asList("p"));
+    public static final Set<String> PARAGRAPH_TAGS = Set.of("p");
 
-    public static final Set<String> HEADING_TAGS = new HashSet<String>(
-            Arrays.asList("h1", "h2", "h3", "h4", "h5", "h6"));
+    public static final Set<String> HEADING_TAGS = Set.of("h1", "h2", "h3", "h4", "h5", "h6");
 
     public static final Pattern INTERWIKI_PATTERN = Pattern.compile("http://[\\w-]+\\.wikipedia\\.org/wiki/.*");
 
-    protected final List<Annotation> wikilinks = new ArrayList<Annotation>();
+    protected final List<Annotation> wikilinks = new ArrayList<>();
 
-    protected final List<Annotation> headers = new ArrayList<Annotation>();
+    protected final List<Annotation> headers = new ArrayList<>();
 
-    protected final List<Annotation> paragraphs = new ArrayList<Annotation>();
+    protected final List<Annotation> paragraphs = new ArrayList<>();
 
     protected String languageCode = "en";
 
@@ -91,24 +87,21 @@ public class AnnotatingMarkupParser implements ITextConverter {
         model = makeWikiModel(languageCode);
     }
 
-    public WikiModel makeWikiModel(String languageCode) {
-        return new WikiModel(String.format(
-                "http:/%s.wikipedia.org/wiki/${image}", languageCode),
-                String.format("http://%s.wikipedia.org/wiki/${title}",
-                        languageCode)) {
+    public WikiModel makeWikiModel(String langCode) {
+        return new WikiModel(String.format("https:/%s.wikipedia.org/wiki/${image}", langCode),
+                String.format("https://%s.wikipedia.org/wiki/${title}", langCode)) {
             @Override
             public String getRawWikiContent(String namespace,
                     String articleName, Map<String, String> templateParameters) {
                 // disable template support
-                // TODO: we need to readd template support at least for dates
+                // TODO: we need to re-add template support at least for dates
                 return "";
             }
         };
     }
 
-
-    public void nodesToText(List<? extends Object> nodes, Appendable buffer,
-            IWikiModel model) throws IOException {
+    @Override
+    public void nodesToText(List<?> nodes, Appendable buffer, IWikiModel model) throws IOException {
         CountingAppendable countingBuffer;
         if (buffer instanceof CountingAppendable) {
             countingBuffer = (CountingAppendable) buffer;
@@ -179,22 +172,18 @@ public class AnnotatingMarkupParser implements ITextConverter {
                             // sentences with links to entities
                             hasSpecialHandling = true;
                             ImageFormat iformat = (ImageFormat) oAttributes.get(WIKIOBJECT_ATTR_KEY);
-                            imageNodeToText(tagNode, iformat, countingBuffer,
-                                    model);
+                            imageNodeToText(tagNode, iformat, countingBuffer, model);
                         }
                         if (!hasSpecialHandling) {
-                            nodesToText(tagNode.getChildren(), countingBuffer,
-                                    model);
+                            nodesToText(tagNode.getChildren(), countingBuffer, model);
                         }
                         if (PARAGRAPH_TAGS.contains(tagName)) {
                             paragraphs.add(new Annotation(tagBegin,
-                                    countingBuffer.currentPosition,
-                                    "paragraph", tagName));
+                                    countingBuffer.currentPosition, "paragraph", tagName));
                             countingBuffer.append("\n\n");
                         } else if (HEADING_TAGS.contains(tagName)) {
                             headers.add(new Annotation(tagBegin,
-                                countingBuffer.currentPosition, "heading",
-                                    tagName));
+                                countingBuffer.currentPosition, "heading", tagName));
                             countingBuffer.append("\n\n");
                         } else if ("a".equals(tagName)) {
                           String href = attributes.get(HREF_ATTR_KEY);
@@ -212,11 +201,13 @@ public class AnnotatingMarkupParser implements ITextConverter {
         }
     }
 
+    @Override
     public void imageNodeToText(TagNode tagNode, ImageFormat imageFormat,
             Appendable buffer, IWikiModel model) throws IOException {
 //        nodesToText(tagNode.getChildren(), buffer, model);
     }
 
+    @Override
     public boolean noLinks() {
         return true;
     }
@@ -234,7 +225,7 @@ public class AnnotatingMarkupParser implements ITextConverter {
     }
 
     public List<String> getParagraphs() {
-        List<String> texts = new ArrayList<String>();
+        List<String> texts = new ArrayList<>();
         for (Annotation p : paragraphs) {
             texts.add(text.substring(p.begin, p.end));
         }
@@ -242,7 +233,7 @@ public class AnnotatingMarkupParser implements ITextConverter {
     }
 
     public List<String> getHeaders() {
-        List<String> texts = new ArrayList<String>();
+        List<String> texts = new ArrayList<>();
         for (Annotation h : headers) {
             texts.add(text.substring(h.begin, h.end));
         }
@@ -253,7 +244,7 @@ public class AnnotatingMarkupParser implements ITextConverter {
         return redirect;
     }
 
-    public class CountingAppendable implements Appendable {
+    public static class CountingAppendable implements Appendable {
 
         public int currentPosition = 0;
 
@@ -263,18 +254,20 @@ public class AnnotatingMarkupParser implements ITextConverter {
             this.wrappedBuffer = wrappedBuffer;
         }
 
+        @Override
         public Appendable append(CharSequence charSeq) throws IOException {
             currentPosition += charSeq.length();
             return wrappedBuffer.append(charSeq);
         }
 
+        @Override
         public Appendable append(char aChar) throws IOException {
             currentPosition += 1;
             return wrappedBuffer.append(aChar);
         }
 
-        public Appendable append(CharSequence charSeq, int start, int end)
-                throws IOException {
+        @Override
+        public Appendable append(CharSequence charSeq, int start, int end) throws IOException {
             currentPosition += end - start;
             return wrappedBuffer.append(charSeq, start, end);
         }

--- a/wikinews-importer/src/main/java/org/apache/opennlp/wikinews_importer/UimaUtil.java
+++ b/wikinews-importer/src/main/java/org/apache/opennlp/wikinews_importer/UimaUtil.java
@@ -58,8 +58,7 @@ public class UimaUtil {
     TypeSystemDescription typeSystemDesciptor;
 
     try {
-      typeSystemDesciptor = (TypeSystemDescription) xmlParser
-          .parse(xmlTypeSystemSource);
+      typeSystemDesciptor = (TypeSystemDescription) xmlParser.parse(xmlTypeSystemSource);
 
       typeSystemDesciptor.resolveImports();
     } catch (InvalidXMLException e) {
@@ -109,11 +108,10 @@ public class UimaUtil {
       throw new IllegalStateException("SAX error while creating parser!", e);
     }
 
-    XmiCasDeserializer dezerializer = new XmiCasDeserializer(
-        cas.getTypeSystem());
+    XmiCasDeserializer deserializer = new XmiCasDeserializer(cas.getTypeSystem());
 
     try {
-      saxParser.parse(xmiIn, dezerializer.getXmiCasHandler(cas));
+      saxParser.parse(xmiIn, deserializer.getXmiCasHandler(cas));
     } catch (SAXException e) {
       throw new IOException("Invalid XMI input!", e);
     }


### PR DESCRIPTION
- adjusts parent project (org.apache.apache) to version 18
- adjusts Java language level to 11
- updates `uimaj` dependencies to version 3.3.1
- update other dependencies to more recent versions
- modernizes resource handling in `WikinewsConverter`
- corrects some formatting issues
- removes unused imports