### PR TITLE
Migrate sandbox component 'caseditor-corpus-server-plugin' to Java 11

### DIFF
--- a/caseditor-corpus-server-plugin/pom.xml
+++ b/caseditor-corpus-server-plugin/pom.xml
@@ -20,62 +20,65 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-
 	<parent>
 		<groupId>org.apache</groupId>
 		<artifactId>apache</artifactId>
-		<version>9</version>
+		<!-- TODO OPENNLP-1452 once this is resolved, move to 29 as well. -->
+		<version>18</version>
 		<relativePath />
 	</parent>
 
 	<groupId>org.apache.opennlp</groupId>
 
 	<artifactId>caseditor-corpus-server-plugin</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>Cas Editor Corpus Server Plugin</name>
+
+	<properties>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+		<uimaj.version>3.3.1</uimaj.version>
+	</properties>
 
 	<repositories>
 		<repository>
 			<id>eclipsePlugins</id>
 			<name>Eclipse components</name>
 			<layout>default</layout>
-			<url>http://repo1.maven.org/eclipse</url>
+			<url>https://repo.eclipse.org</url>
+
 			<releases>
 				<updatePolicy>never</updatePolicy>
 				<checksumPolicy>fail</checksumPolicy>
 			</releases>
+
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
 		</repository>
-    
-    	<repository>
-			<id>maven2-repository.java.net</id>
-			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
-			<layout>default</layout>
-		</repository>
-    </repositories>
-    
+	</repositories>
+
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.5</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 		    <groupId>com.sun.jersey</groupId>
 		    <artifactId>jersey-json</artifactId>
-		    <version>1.9.1</version>
+		    <version>1.19.4</version>
 		</dependency>
 
 		<dependency>
 		    <groupId>com.sun.jersey</groupId>
 		    <artifactId>jersey-client</artifactId>
-		    <version>1.9.1</version>
+		    <version>1.19.4</version>
 		</dependency>
 		
 		<!-- UIMA dependencies -->
@@ -83,21 +86,21 @@
 		<dependency>
 			<groupId>org.apache.uima</groupId>
 			<artifactId>uimaj-core</artifactId>
-			<version>2.4.0</version>
+			<version>${uimaj.version}</version>
 			<scope>compile</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.uima</groupId>
 			<artifactId>uimaj-tools</artifactId>
-			<version>2.4.0</version>
+			<version>${uimaj.version}</version>
 			<scope>compile</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.uima</groupId>
 			<artifactId>uimaj-ep-cas-editor</artifactId>
-			<version>2.4.0</version>
+			<version>${uimaj.version}</version>
 			<scope>compile</scope>
 		</dependency>
 		
@@ -125,11 +128,11 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.eclipse.swt</groupId>
-			<artifactId>org.eclipse.swt.win32.win32.x86</artifactId>
-			<!-- changing the lower version number to 3.2.0, was 3.3.0 because only 
+			<groupId>org.eclipse.swt.win32.win32</groupId>
+			<artifactId>x86</artifactId>
+			<!-- changing the lower version number to 3.2.0, was 3.3.0 because only
 				3.2.0 and 3.2.1 are in repo -->
-			<version>[3.2.0.0,4.0.0)</version>
+			<version>[3.3.0.0,4.0.0)</version>
 			<scope>provided</scope>
 		</dependency>
 
@@ -167,7 +170,7 @@
 	<build>
 		<!-- don't use artifactId as first part of finalName, follow instead the 
 			eclipse convention -->
-		<finalName>org.apache.opennlp.corpus_server.caseditor_0.0.1</finalName>
+		<finalName>org.apache.opennlp.corpus_server.caseditor_2.1.1</finalName>
 		<resources>
 			<resource>
 				<directory>.</directory>
@@ -186,8 +189,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>${maven.compiler.source}</source>
+					<target>${maven.compiler.target}</target>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -201,10 +204,11 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
+				<version>5.1.8</version>
 				<executions>
 					<execution>
-    	                 <goals><goal>manifest</goal></goals>
-		                 <phase>process-classes</phase>
+					 	<goals><goal>manifest</goal></goals>
+					 	<phase>process-classes</phase>
 						<configuration>
 							<manifestLocation>META-INF/</manifestLocation>
 							<instructions>
@@ -224,7 +228,7 @@
 									org.eclipse.ui.workbench,
 									org.eclipse.core.runtime,
 									org.eclipse.core.resources,
-									org.junit4;bundle-version="4.5.0";resolution:=optional
+									org.junit4;bundle-version="4.13.2";resolution:=optional
 								</Require-Bundle>
 								<Import-Package>
 									!org.eclipse.jface.text,

--- a/caseditor-corpus-server-plugin/src/main/java/org/apache/opennlp/corpus_server/caseditor/CorpusExplorerView.java
+++ b/caseditor-corpus-server-plugin/src/main/java/org/apache/opennlp/corpus_server/caseditor/CorpusExplorerView.java
@@ -117,12 +117,12 @@ public class CorpusExplorerView extends ViewPart {
           @Override
           public void run() {
             if (event.getResult().isOK()) {
-              
+
               setMessage(null);
-              
+
               searchResultViewer.setItemCount(0);
               JSONArray searchResult = searchJob.getSearchResult();
-              
+
               for (int i = 0; i < searchResult.length(); i++) {
                 try {
                   searchResultViewer.add(searchResult.getString(i));
@@ -192,16 +192,15 @@ public class CorpusExplorerView extends ViewPart {
       lastUsedSearchQueriesString = "*:*";
     }
     
-    String lastUsedQueries[] = lastUsedSearchQueriesString.split(LUCENE_QUERY_DELIMITER);
+    String[] lastUsedQueries = lastUsedSearchQueriesString.split(LUCENE_QUERY_DELIMITER);
     
     if (lastUsedQueries.length > 0)
       queryText.setText(lastUsedQueries[0]);
-    
-    for (int i = 0; i < lastUsedQueries.length; i++) {
-      queryText.add(lastUsedQueries[i]);
+
+    for (String lastUsedQuery : lastUsedQueries) {
+      queryText.add(lastUsedQuery);
     }
-    
-    
+
     queryText.addSelectionListener(new SelectionListener() {
       
       @Override

--- a/caseditor-corpus-server-plugin/src/main/java/org/apache/opennlp/corpus_server/caseditor/CorpusServerCasEditorInput.java
+++ b/caseditor-corpus-server-plugin/src/main/java/org/apache/opennlp/corpus_server/caseditor/CorpusServerCasEditorInput.java
@@ -24,8 +24,8 @@ import org.eclipse.ui.IPersistableElement;
 // Serialization must be supported, right?!
 public class CorpusServerCasEditorInput implements IEditorInput {
 
-  private String corpusUrl;
-  private String casId;
+  private final String corpusUrl;
+  private final String casId;
   
   CorpusServerCasEditorInput(String corpusUrl, String casId) {
     this.corpusUrl = corpusUrl;
@@ -33,7 +33,7 @@ public class CorpusServerCasEditorInput implements IEditorInput {
   }
   
   @Override
-  public Object getAdapter(@SuppressWarnings("rawtypes") Class clazz) {
+  public Object getAdapter(Class clazz) {
     return null;
   }
 

--- a/caseditor-corpus-server-plugin/src/main/java/org/apache/opennlp/corpus_server/caseditor/CorpusServerPlugin.java
+++ b/caseditor-corpus-server-plugin/src/main/java/org/apache/opennlp/corpus_server/caseditor/CorpusServerPlugin.java
@@ -34,11 +34,13 @@ public class CorpusServerPlugin extends AbstractUIPlugin {
   public CorpusServerPlugin() {
   }
 
+  @Override
   public void start(BundleContext context) throws Exception {
     super.start(context);
     plugin = this;
   }
 
+  @Override
   public void stop(BundleContext context) throws Exception {
     plugin = null;
     super.stop(context);

--- a/caseditor-corpus-server-plugin/src/main/java/org/apache/opennlp/corpus_server/caseditor/DefaultCasDocumentProvider.java
+++ b/caseditor-corpus-server-plugin/src/main/java/org/apache/opennlp/corpus_server/caseditor/DefaultCasDocumentProvider.java
@@ -24,9 +24,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,7 +34,7 @@ import javax.ws.rs.core.MediaType;
 import org.apache.uima.ResourceSpecifierFactory;
 import org.apache.uima.UIMAFramework;
 import org.apache.uima.cas.CAS;
-import org.apache.uima.caseditor.editor.DocumentFormat;
+import org.apache.uima.cas.SerialFormat;
 import org.apache.uima.caseditor.editor.DocumentUimaImpl;
 import org.apache.uima.caseditor.editor.ICasDocument;
 import org.apache.uima.caseditor.editor.ICasEditor;
@@ -48,9 +47,15 @@ import org.apache.uima.util.CasCreationUtils;
 import org.apache.uima.util.InvalidXMLException;
 import org.apache.uima.util.XMLInputSource;
 import org.apache.uima.util.XMLParser;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.preference.PreferenceStore;
@@ -65,10 +70,9 @@ public class DefaultCasDocumentProvider extends
 
   private static final int READ_TIMEOUT = 30000;
   
-  private Map<Object, PreferenceStore> tsPreferenceStores =
-      new HashMap<Object, PreferenceStore>();
+  private final Map<Object, PreferenceStore> tsPreferenceStores = new HashMap<>();
   
-  private Map<String, IPreferenceStore> sessionPreferenceStores = new HashMap<String, IPreferenceStore>();
+  private final Map<String, IPreferenceStore> sessionPreferenceStores = new HashMap<>();
   
   private static TypeSystemDescription createTypeSystemDescription(InputStream in) throws IOException {
 
@@ -77,21 +81,18 @@ public class DefaultCasDocumentProvider extends
     // resolving a referenced type system will fail
 
     XMLInputSource xmlTypeSystemSource = new XMLInputSource(in, new File(""));
-
     XMLParser xmlParser = UIMAFramework.getXMLParser();
 
-    TypeSystemDescription typeSystemDesciptor;
+    TypeSystemDescription typeSystemDescriptor;
 
     try {
-      typeSystemDesciptor = (TypeSystemDescription) xmlParser
-          .parse(xmlTypeSystemSource);
-
-      typeSystemDesciptor.resolveImports();
+      typeSystemDescriptor = (TypeSystemDescription) xmlParser.parse(xmlTypeSystemSource);
+      typeSystemDescriptor.resolveImports();
     } catch (InvalidXMLException e) {
       throw new IOException(e);
     }
 
-    return typeSystemDesciptor;
+    return typeSystemDescriptor;
   }
   
   private static CAS createEmptyCAS(TypeSystemDescription typeSystem) {
@@ -135,17 +136,14 @@ public class DefaultCasDocumentProvider extends
       //       for every opened CAS, a time stamp can be used to detect
       //       if it has been changed or not.
       
-      ClientResponse tsResponse = webResource
-              .path("_typesystem")
+      ClientResponse tsResponse = webResource.path("_typesystem")
               .accept(MediaType.TEXT_XML)
               // TODO: How to fix this? Shouldn't accept do it?
               .header("Content-Type", MediaType.TEXT_XML)
               .get(ClientResponse.class);
       
-      InputStream tsIn = tsResponse.getEntityInputStream();
       TypeSystemDescription tsDesc = null;
-      
-      try {
+      try (InputStream tsIn = tsResponse.getEntityInputStream()) {
         tsDesc = createTypeSystemDescription(tsIn);
       }
       catch (IOException e) {
@@ -155,42 +153,29 @@ public class DefaultCasDocumentProvider extends
         // TODO: Stop here, and display some kind of
         // error message to the user
       }
-      finally {
-        try {
-          tsIn.close();
-        } catch (IOException e) {
-        }
-      }
-      // create an empty cas ..
+
+      // create an empty cas...
       CAS cas = createEmptyCAS(tsDesc);
       
       ClientResponse casResponse;
-      try {
-        casResponse = webResource
-            .path(URLEncoder.encode(casInput.getName(), "UTF-8"))
-            .accept(MediaType.TEXT_XML)
-            // TODO: How to fix this? Shouldn't accept do it?
-            .header("Content-Type", MediaType.TEXT_XML)
-            .get(ClientResponse.class);
-      } catch (UnsupportedEncodingException e) {
-        throw new RuntimeException("Should never fail, UTF-8 encoding is available on every JRE!", e);
+      casResponse = webResource.path(URLEncoder.encode(casInput.getName(), StandardCharsets.UTF_8))
+          .accept(MediaType.TEXT_XML)
+          // TODO: How to fix this? Shouldn't accept do it?
+          .header("Content-Type", MediaType.TEXT_XML)
+          .get(ClientResponse.class);
+
+      org.apache.uima.caseditor.editor.ICasDocument doc;
+      try (InputStream casIn = casResponse.getEntityInputStream()) {
+        IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
+        IPath pluginStatePath = CorpusServerPlugin.getDefault().getStateLocation();
+        IPath tempPath = pluginStatePath.append(casInput.getName()).addFileExtension(MediaType.TEXT_XML);
+        IFile casFile = root.getFile(tempPath);
+        casFile.setContents(casIn, IResource.FORCE, new NullProgressMonitor());
+        doc = new DocumentUimaImpl(cas, casFile, SerialFormat.XMI.name());
+      } catch (IOException e) {
+        throw new RuntimeException(e.getLocalizedMessage(), e);
       }
-      
-      InputStream casIn = casResponse.getEntityInputStream();
-      
-      org.apache.uima.caseditor.editor.ICasDocument doc = null;
-      
-      try {
-        doc = new DocumentUimaImpl(cas, casIn, DocumentFormat.XMI);
-      }
-      // TODO: Catch exception here, and display error message?!
-      finally {
-        try {
-          casIn.close();
-        } catch (IOException e) {
-        }
-      }
-      
+
       return doc;
     }
 
@@ -219,18 +204,11 @@ public class DefaultCasDocumentProvider extends
         client.setReadTimeout(READ_TIMEOUT);
         WebResource webResource = client.resource(casInput.getServerUrl());
         
-        byte xmiBytes[] = outStream.toByteArray();
+        byte[] xmiBytes = outStream.toByteArray();
         
-        String encodedCasId;
-        try {
-          encodedCasId = URLEncoder.encode(casInput.getName(), "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-          throw new CoreException(new Status(Status.ERROR, CorpusServerPlugin.PLUGIN_ID,
-              "Severe error, should never happen, UTF-8 encoding is not supported!"));
-        }
-        
-        ClientResponse response = webResource
-                .path(encodedCasId)
+        String encodedCasId = URLEncoder.encode(casInput.getName(), StandardCharsets.UTF_8);
+
+        ClientResponse response = webResource.path(encodedCasId)
                 .accept(MediaType.TEXT_XML)
                 // TODO: How to fix this? Shouldn't accept do it?
                 .header("Content-Type", MediaType.TEXT_XML)
@@ -288,15 +266,12 @@ public class DefaultCasDocumentProvider extends
     if (tsStore == null) {
       
       IPreferenceStore store = CorpusServerPlugin.getDefault().getPreferenceStore();
-      
       String tsStoreString = store.getString(getTypeSystemId((CorpusServerCasEditorInput) element));
       
       tsStore = new PreferenceStore();
       
       if (tsStoreString.length() != 0) { 
-        InputStream tsStoreIn = new ByteArrayInputStream(tsStoreString.getBytes(Charset.forName("UTF-8")));
-        
-        try {
+        try (InputStream tsStoreIn = new ByteArrayInputStream(tsStoreString.getBytes(StandardCharsets.UTF_8))) {
           tsStore.load(tsStoreIn);
         } catch (IOException e) {
           e.printStackTrace();
@@ -305,8 +280,6 @@ public class DefaultCasDocumentProvider extends
       
       tsPreferenceStores.put(element, tsStore);
     }
-    
-    
     return tsStore;
   }
 
@@ -316,18 +289,14 @@ public class DefaultCasDocumentProvider extends
     PreferenceStore tsStore = tsPreferenceStores.get(element);
     
     if (tsStore != null) {
-      ByteArrayOutputStream tsStoreBytes = new ByteArrayOutputStream();
-      try {
+      try (ByteArrayOutputStream tsStoreBytes = new ByteArrayOutputStream()) {
         tsStore.save(tsStoreBytes, "");
+        IPreferenceStore store = CorpusServerPlugin.getDefault().getPreferenceStore();
+        store.putValue(getTypeSystemId((CorpusServerCasEditorInput) element),
+                tsStoreBytes.toString(StandardCharsets.UTF_8));
       } catch (IOException e) {
-        // TODO Auto-generated catch block
         e.printStackTrace();
       }
-      
-      IPreferenceStore store = CorpusServerPlugin.getDefault().getPreferenceStore();
-      store.putValue(getTypeSystemId((CorpusServerCasEditorInput) element), 
-          new String(tsStoreBytes.toByteArray(), Charset.forName("UTF-8")));
     }
-    
   }
 }

--- a/caseditor-corpus-server-plugin/src/main/java/org/apache/opennlp/corpus_server/caseditor/TaskQueueView.java
+++ b/caseditor-corpus-server-plugin/src/main/java/org/apache/opennlp/corpus_server/caseditor/TaskQueueView.java
@@ -25,7 +25,6 @@ import javax.ws.rs.core.MediaType;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.viewers.ILabelProviderListener;
 import org.eclipse.jface.viewers.IOpenListener;
-import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.ITableLabelProvider;
 import org.eclipse.jface.viewers.OpenEvent;
 import org.eclipse.jface.viewers.StructuredSelection;
@@ -53,17 +52,16 @@ import com.sun.jersey.api.client.WebResource;
  */
 public class TaskQueueView extends ViewPart {
 
-  private Composite explorerComposite;
   private Text serverUrl;
   
   private TableViewer historyViewer;
   
-  private List<IEditorInput> lastInputElements = new ArrayList<IEditorInput>();
+  private final List<IEditorInput> lastInputElements = new ArrayList<>();
       
   @Override
   public void createPartControl(Composite parent) {
 
-    explorerComposite = new Composite(parent, SWT.NONE);
+    Composite explorerComposite = new Composite(parent, SWT.NONE);
     GridLayout explorerLayout = new GridLayout();
     explorerLayout.numColumns = 2;
     explorerComposite.setLayout(explorerLayout);
@@ -76,10 +74,10 @@ public class TaskQueueView extends ViewPart {
     GridDataFactory.swtDefaults().align(SWT.FILL, SWT.CENTER).grab(true, false)
         .applyTo(serverUrl);
     
-    // TOOD: Should be stored in some way, or just done more sophisticated ..
+    // TODO: Should be stored in some way, or just done more sophisticated ..
     serverUrl.setText("http://localhost:8080/corpus-server/rest/queues/ObamaNerTask");
     
-    // Button for next cas (gets nexts and closes current one,
+    // Button for next cas (gets next and closes current one,
     // if not saved user is asked for it)
     Button nextDocument = new Button(explorerComposite, SWT.BORDER);
     nextDocument.setText("Next");
@@ -109,7 +107,7 @@ public class TaskQueueView extends ViewPart {
         // we also need to corpus the cas id belongs too ...
         IWorkbenchPage page = TaskQueueView.this.getSite().getPage();
         
-        // TODO: Thats a short cut, we need to make this work properly ...
+        // TODO: That's a short cut, we need to make this work properly ...
         IEditorInput input = new CorpusServerCasEditorInput(
             "http://localhost:8080/corpus-server/rest/corpora/wikinews", casId);
 


### PR DESCRIPTION
- adjusts parent project (org.apache.apache) to version 18
- adjusts Java language level to 11
- updates `uimaj` dependencies to version 3.3.1
- updates `jersey` dependencies to version 1.19.4
- cures some deprecation issues
- improves existing JavaDoc