### PR TITLE
OPENNLP-1630 Move to Apache Parent 33

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>31</version>
+        <version>33</version>
         <relativePath />
     </parent>
 
@@ -130,12 +130,9 @@
         
         <junit.version>5.11.2</junit.version>
 
-        <enforcer.plugin.version>3.0.0-M3</enforcer.plugin.version>
-        <checkstyle.plugin.version>3.2.0</checkstyle.plugin.version>
         <coveralls.maven.plugin>4.3.0</coveralls.maven.plugin>
         <jacoco.maven.plugin>0.8.12</jacoco.maven.plugin>
-        <maven.surefire.plugin>3.0.0-M5</maven.surefire.plugin>
-        <maven.failsafe.plugin>3.0.0-M5</maven.failsafe.plugin>
+        <maven.failsafe.plugin>3.5.1</maven.failsafe.plugin>
         <forbiddenapis.plugin>3.8</forbiddenapis.plugin>
         <mockito.version>3.9.0</mockito.version>
     </properties>
@@ -341,7 +338,6 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>${maven.surefire.plugin}</version>
                     <configuration>
                         <argLine>-Xmx2048m -Dfile.encoding=UTF-8</argLine>
                         <forkCount>${opennlp.forkCount}</forkCount>
@@ -406,7 +402,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
+                <version>3.13.0</version>
                 <configuration>
                     <release>${java.version}</release>
                     <compilerArgument>-Xlint</compilerArgument>
@@ -459,7 +455,6 @@
 
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.5.0</version>
                 <configuration>
                     <doclint>none</doclint>
                     <source>${java.version}</source>
@@ -507,7 +502,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>${enforcer.plugin.version}</version>
                 <executions>
                     <execution>
                         <id>enforce-java</id>
@@ -543,7 +537,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>${checkstyle.plugin.version}</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Change
-
- aligns Apache parent project version to '33', see [changelog](https://github.com/apache/maven-apache-parent/releases/tag/apache-33).
- drops outdated, custom-managed maven plugin versions (now via parent)
- updates maven.failsafe plugin to version 3.5.1


Tasks
-
Thank you for contributing to Apache OpenNLP.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn clean install` at the root opennlp-sandbox folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp-sandbox folder?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp-sandbox folder?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions for build issues and submit an update to your PR as soon as possible.
