### PR TITLE
OPENNLP-1670: Disable releases for apache.snapshots repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,9 @@
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
         </repository>
     </repositories>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Same as https://github.com/apache/opennlp/pull/711, for the sandbox.

## How was this patch tested?

```
$ mvn -N --batch-mode eu.maveniverse.maven.plugins:toolbox:list-repositories
...
[INFO] --- toolbox:0.6.0:list-repositories (default-cli) @ opennlp-sandbox ---
[INFO] Remote repositories used by project org.apache.opennlp:opennlp-sandbox:pom:2.5.2-SNAPSHOT.
[INFO]  * central (https://repo.maven.apache.org/maven2/, default, releases)
[INFO]    First introduced on root
[INFO]  * apache.snapshots (https://repository.apache.org/snapshots, default, snapshots)
[INFO]    First introduced on root
```