### PR TITLE
OPENNLP-1676: Add stricter argument validation in WSD component

### DIFF
--- a/opennlp-wsd/src/main/java/opennlp/tools/cmdline/disambiguator/DisambiguatorTool.java
+++ b/opennlp-wsd/src/main/java/opennlp/tools/cmdline/disambiguator/DisambiguatorTool.java
@@ -34,6 +34,7 @@ import opennlp.tools.cmdline.SystemInputStreamFactory;
 import opennlp.tools.cmdline.TerminateToolException;
 import opennlp.tools.disambiguator.Disambiguator;
 import opennlp.tools.disambiguator.Lesk;
+import opennlp.tools.disambiguator.LeskParameters;
 import opennlp.tools.disambiguator.WSDDefaultParameters;
 import opennlp.tools.disambiguator.WSDHelper;
 import opennlp.tools.disambiguator.WSDSample;
@@ -103,9 +104,9 @@ public class DisambiguatorTool extends CmdLineTool {
     Disambiguator wsd = null;
 
     if (params.getType().equalsIgnoreCase("mfs")) {
-      wsd = new MFS();
+      wsd = new MFS(WSDDefaultParameters.defaultParams());
     } else if (params.getType().equalsIgnoreCase("lesk")) {
-      wsd = new Lesk();
+      wsd = new Lesk(new LeskParameters());
     } else if (params.getType().equalsIgnoreCase("ims")) {
       // TODO Set a "default" model for ENG -> future!?
       wsd = new WSDisambiguatorME(null, WSDDefaultParameters.defaultParams());

--- a/opennlp-wsd/src/main/java/opennlp/tools/disambiguator/AbstractWSDisambiguator.java
+++ b/opennlp-wsd/src/main/java/opennlp/tools/disambiguator/AbstractWSDisambiguator.java
@@ -19,7 +19,6 @@
 
 package opennlp.tools.disambiguator;
 
-import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -28,9 +27,10 @@ import net.sf.extjwnl.JWNLException;
 import net.sf.extjwnl.data.POS;
 import net.sf.extjwnl.data.Synset;
 import net.sf.extjwnl.data.Word;
-import opennlp.tools.util.Span;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import opennlp.tools.util.Span;
 
 /**
  * A base implementation of {@link Disambiguator}.
@@ -50,7 +50,11 @@ abstract class AbstractWSDisambiguator implements Disambiguator {
 
   private static final Pattern SPLIT = Pattern.compile("\\.");
 
-  protected WSDParameters params;
+  private final WSDParameters params;
+
+  protected AbstractWSDisambiguator(WSDParameters params) {
+    this.params = params;
+  }
 
   /**
    * @return Retrieves the parameters of the disambiguation algorithm.
@@ -60,20 +64,17 @@ abstract class AbstractWSDisambiguator implements Disambiguator {
   }
 
   /**
-   * @param params Sets the disambiguation implementation specific parameters.
-   *
-   * @throws InvalidParameterException Thrown if specified parameters are invalid.
-   */
-  public void setParams(WSDParameters params) throws InvalidParameterException {
-    this.params = params;
-  }
-
-  /**
    * {@inheritDoc}
    */
   @Override
   public String disambiguate(String[] tokenizedContext, String[] tokenTags,
                              String[] lemmas, int ambiguousTokenIndex) {
+    if (tokenizedContext == null || tokenTags == null || lemmas == null) {
+      throw new IllegalArgumentException("Parameters must not be null!");
+    }
+    if (ambiguousTokenIndex < 0) {
+      throw new IllegalArgumentException("Parameter ambiguousTokenIndex must not be negative!");
+    }
     return disambiguate(new WSDSample(tokenizedContext, tokenTags, lemmas, ambiguousTokenIndex));
   }
 
@@ -83,6 +84,10 @@ abstract class AbstractWSDisambiguator implements Disambiguator {
   @Override
   public List<String> disambiguate(String[] tokenizedContext, String[] tokenTags,
                                    String[] lemmas, Span ambiguousTokenIndexSpan) {
+    if (tokenizedContext == null || tokenTags == null || lemmas == null
+            || ambiguousTokenIndexSpan == null) {
+      throw new IllegalArgumentException("Parameters must not be null!");
+    }
     List<String> senses = new ArrayList<>();
 
     int start = Math.max(0, ambiguousTokenIndexSpan.getStart());
@@ -113,7 +118,9 @@ abstract class AbstractWSDisambiguator implements Disambiguator {
   @Override
   public List<String> disambiguate(String[] tokenizedContext, String[] tokenTags,
                                    String[] lemmas) {
-
+    if (tokenizedContext == null || tokenTags == null || lemmas == null) {
+      throw new IllegalArgumentException("Parameters must not be null!");
+    }
     List<String> senses = new ArrayList<>();
     for (int i = 0; i < tokenizedContext.length; i++) {
 

--- a/opennlp-wsd/src/main/java/opennlp/tools/disambiguator/Disambiguator.java
+++ b/opennlp-wsd/src/main/java/opennlp/tools/disambiguator/Disambiguator.java
@@ -43,7 +43,9 @@ public interface Disambiguator {
    * Conducts disambiguation for a {@link WSDSample} context.
    *
    * @param sample    The {@link WSDSample} containing the word and POS tags to use.
+   *
    * @return The sense of the {@code sample} to disambiguate.
+   * @throws IllegalArgumentException Thrown if parameters were invalid.
    */
   String disambiguate(WSDSample sample);
   
@@ -51,11 +53,16 @@ public interface Disambiguator {
    * Conducts disambiguation for a single word located at {@code ambiguousTokenIndex}.
    *
    * @param tokenizedContext    The text containing the word to disambiguate.
+   *                            Must not be {@code null}.
    * @param tokenTags           The tags corresponding to the context.
+   *                            Must not be {@code null}.
    * @param lemmas              The lemmas of ALL the words in the context.
+   *                            Must not be {@code null}.
    * @param ambiguousTokenIndex The index of the word to disambiguate.
    *                            Must not be less or equal to zero.
+   *
    * @return The sense of the word to disambiguate.
+   * @throws IllegalArgumentException Thrown if parameters were invalid.
    */
   String disambiguate(String[] tokenizedContext, String[] tokenTags,
                       String[] lemmas, int ambiguousTokenIndex);
@@ -64,12 +71,17 @@ public interface Disambiguator {
    * Conducts disambiguation for all word located at {@code ambiguousTokenSpan}.
    *
    * @param tokenizedContext    The text containing the word to disambiguate.
+   *                            Must not be {@code null}.
    * @param tokenTags           The tags corresponding to the context.
+   *                            Must not be {@code null}.
    * @param lemmas              The lemmas of ALL the words in the context.
+   *                            Must not be {@code null}.
    * @param ambiguousTokenSpan  The {@link Span} of the word(s) to disambiguate.
    *                            Must not be {@code null}.
+   *                            
    * @return A List of senses, each corresponding to the senses of each word of
    *         the context which are to be disambiguated.
+   * @throws IllegalArgumentException Thrown if parameters were invalid.
    */
   List<String> disambiguate(String[] tokenizedContext, String[] tokenTags,
                             String[] lemmas, Span ambiguousTokenSpan);
@@ -78,10 +90,15 @@ public interface Disambiguator {
    * Conducts disambiguation for all the words of the {@code tokenizedContext}.
    *
    * @param tokenizedContext    The text containing the word to disambiguate.
+   *                            Must not be {@code null}.
    * @param tokenTags           The tags corresponding to the context.
+   *                            Must not be {@code null}.
    * @param lemmas              The lemmas of ALL the words in the context.
+   *                            Must not be {@code null}.
+   *
    * @return A List of senses, each corresponding to the senses of each word of
    *         the context which are to be disambiguated.
+   * @throws IllegalArgumentException Thrown if parameters were invalid.
    */
   List<String> disambiguate(String[] tokenizedContext, String[] tokenTags,
                             String[] lemmas);

--- a/opennlp-wsd/src/main/java/opennlp/tools/disambiguator/FeaturesExtractor.java
+++ b/opennlp-wsd/src/main/java/opennlp/tools/disambiguator/FeaturesExtractor.java
@@ -140,12 +140,16 @@ public class FeaturesExtractor {
    * qualified for "Surrounding words".
    * 
    * @param trainingData A list of the training samples (type {@link WTDIMS}.
+   *                     Must not be {@code null}.
+   *
    * @return A list of all the surrounding words for the {@code trainingData}.
+   * @throws IllegalArgumentException Thrown if parameters were invalid.
    */
   public List<String> extractTrainingSurroundingWords(List<WTDIMS> trainingData) {
-
+    if (trainingData == null) {
+      throw new IllegalArgumentException("TrainingData must not be null!");
+    }
     Map<String, Object> words = new HashMap<>();
-
     for (WTDIMS word : trainingData) {
       for (String sWord : word.getSurroundingWords()) {
         if (!words.containsKey(sWord.toLowerCase()))
@@ -162,17 +166,20 @@ public class FeaturesExtractor {
    * approach and puts them in the corresponding attributes of
    * the {@link WTDIMS word to disambiguate} object.
    * 
-   * @param wtd The {@link WTDIMS word to disambiguate}.
+   * @param wtd The {@link WTDIMS word to disambiguate}. Must not be {@code null}.
    * @param windowSize The parameter required to generate the features qualified of
-   *                   "PoS of Surrounding Words".
+   *                   "PoS of Surrounding Words". Must be greater or equal to {@code 1}
    * @param ngram The parameter required to generate the features qualified of
-   *              "Local Collocations".
+   *              "Local Collocations". Must be greater or equal to {@code 1}.
    *
    * @throws IllegalArgumentException Thrown if parameters were invalid.
    */
   public void extractIMSFeatures(WTDIMS wtd, int windowSize, int ngram) {
     if (wtd == null) {
-      throw new IllegalArgumentException("WTD must not be null");
+      throw new IllegalArgumentException("Parameter wtd must not be null!");
+    }
+    if (windowSize < 1 || ngram < 1) {
+      throw new IllegalArgumentException("Parameter windowSize or ngram must be at least 1!");
     }
     wtd.setPosOfSurroundingWords(extractPosOfSurroundingWords(wtd, windowSize));
     wtd.setSurroundingWords(extractSurroundingWords(wtd));
@@ -186,14 +193,15 @@ public class FeaturesExtractor {
    * wrapped in the {@link WTDIMS word to disambiguate}.
    * Therefore, it doesn't require any parameters.
    *
-   * @param wtd The {@link WTDIMS word to disambiguate}.
+   * @param wtd The {@link WTDIMS word to disambiguate}. Must not be {@code null}.
    * @param listSurrWords The full list of surrounding words of the training data.
+   *                      Must not be {@code null}.
    *
    * @throws IllegalArgumentException Thrown if parameters were invalid.
    */
   public void serializeIMSFeatures(WTDIMS wtd, List<String> listSurrWords) {
-    if (wtd == null) {
-      throw new IllegalArgumentException("WTD must not be null");
+    if (wtd == null || listSurrWords == null) {
+      throw new IllegalArgumentException("Parameters must not be null!");
     }
     String[] posOfSurroundingWords = wtd.getPosOfSurroundingWords();
     List<String> surroundingWords = new ArrayList<>(

--- a/opennlp-wsd/src/main/java/opennlp/tools/disambiguator/Lesk.java
+++ b/opennlp-wsd/src/main/java/opennlp/tools/disambiguator/Lesk.java
@@ -71,16 +71,6 @@ public class Lesk extends AbstractWSDisambiguator {
   private static final Tokenizer tokenizer = WSDHelper.getTokenizer();
 
   /**
-   * Instantiates a {@link Lesk} instance without explicit parameters,
-   * resulting in a set of default being activated.
-   *
-   * @see LeskParameters
-   */
-  public Lesk() {
-    this(null);
-  }
-
-  /**
    * Instantiates a {@link Lesk} instance and sets the input parameters.
    *
    * @param params If the {@link LeskParameters} are {@code null}, set the default ones,
@@ -88,7 +78,8 @@ public class Lesk extends AbstractWSDisambiguator {
    * @throws IllegalArgumentException Thrown if specified parameters are invalid.
    */
   public Lesk(LeskParameters params) {
-    this.setParams(params);
+    super(params);
+    setParams(params);
   }
 
   /**
@@ -97,7 +88,6 @@ public class Lesk extends AbstractWSDisambiguator {
    *
    * @throws IllegalArgumentException Thrown if specified parameters are invalid.
    */
-  @Override
   public void setParams(WSDParameters params) {
     if (params == null) {
       this.params = new LeskParameters();
@@ -778,16 +768,10 @@ public class Lesk extends AbstractWSDisambiguator {
    * {@inheritDoc}
    */
   @Override
-  public String disambiguate(String[] tokenizedContext, String[] tokenTags,
-                             String[] lemmas, int ambiguousTokenIndex) {
-    return disambiguate(new WSDSample(tokenizedContext, tokenTags, lemmas, ambiguousTokenIndex));
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
   public String disambiguate(WSDSample sample) {
+    if (sample == null) {
+      throw new IllegalArgumentException("WSDSample object must not be null!");
+    }
     if (!WSDHelper.isRelevantPOSTag(sample.getTargetTag())) {
       if (WSDHelper.getNonRelevWordsDef(sample.getTargetTag()) != null) {
         return WSDParameters.SenseSource.WSDHELPER.name() + " " + sample.getTargetTag();

--- a/opennlp-wsd/src/main/java/opennlp/tools/disambiguator/MFS.java
+++ b/opennlp-wsd/src/main/java/opennlp/tools/disambiguator/MFS.java
@@ -42,6 +42,10 @@ public class MFS extends AbstractWSDisambiguator {
 
   public static final String NONESENSE = "nonesense";
 
+  public MFS(WSDParameters params) {
+    super(params);
+  }
+
   /**
    * Extracts the most frequent sense for a specified {@link WSDSample}.
    *
@@ -101,6 +105,9 @@ public class MFS extends AbstractWSDisambiguator {
    */
   @Override
   public String disambiguate(WSDSample sample) {
+    if (sample == null) {
+      throw new IllegalArgumentException("WSDSample object must not be null!");
+    }
     String targetTag = sample.getTargetTag();
     if (WSDHelper.isRelevantPOSTag(targetTag)) {
       return disambiguate(sample.getTargetWordTag());

--- a/opennlp-wsd/src/main/java/opennlp/tools/disambiguator/WSDisambiguatorME.java
+++ b/opennlp-wsd/src/main/java/opennlp/tools/disambiguator/WSDisambiguatorME.java
@@ -55,10 +55,10 @@ public class WSDisambiguatorME extends AbstractWSDisambiguator {
    * @throws IllegalArgumentException Thrown if specified parameters are invalid.
    */
   public WSDisambiguatorME(WSDModel model, WSDParameters params) {
+    super(params);
     if (model == null || params == null) {
       throw new IllegalArgumentException("Parameters cannot be null!");
     }
-    super.params = params;
     this.model = model;
     WSDisambiguatorFactory factory = model.getWSDFactory();
     cg = factory.getContextGenerator();
@@ -132,22 +132,16 @@ public class WSDisambiguatorME extends AbstractWSDisambiguator {
     samples.reset();
     return surroundingWordsModel;
   }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public String disambiguate(String[] tokenizedContext, String[] tokenTags,
-                             String[] lemmas, int index) {
-    return disambiguate(new WSDSample(tokenizedContext, tokenTags, lemmas, index));
-  }
   
   /**
    * {@inheritDoc}
    */
   @Override
   public String disambiguate(WSDSample sample) {
-    final WSDDefaultParameters defParams = ((WSDDefaultParameters) params);
+    if (sample == null) {
+      throw new IllegalArgumentException("WSDSample object must not be null!");
+    }
+    final WSDDefaultParameters defParams = ((WSDDefaultParameters) getParams());
     final int wSize = defParams.getIntParameter(
             WSDDefaultParameters.WINDOW_SIZE_PARAM, WSDDefaultParameters.WINDOW_SIZE_DEFAULT);
     final int ngram = defParams.getIntParameter(
@@ -163,7 +157,7 @@ public class WSDisambiguatorME extends AbstractWSDisambiguator {
         String outcome = model.getWSDMaxentModel().getBestOutcome(outcomeProbs);
 
         if (outcome != null && !outcome.isEmpty()) {
-          return params.getSenseSource().name() + " " + wordTag.split("\\.")[0] + "%" + outcome;
+          return getParams().getSenseSource().name() + " " + wordTag.split("\\.")[0] + "%" + outcome;
         } else {
           return disambiguate(wordTag);
         }

--- a/opennlp-wsd/src/test/java/opennlp/tools/disambiguator/FeaturesExtractorTest.java
+++ b/opennlp-wsd/src/test/java/opennlp/tools/disambiguator/FeaturesExtractorTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FeaturesExtractorTest extends AbstractDisambiguatorTest {
 
@@ -58,6 +59,24 @@ public class FeaturesExtractorTest extends AbstractDisambiguatorTest {
   }
 
   @Test
+  void testExtractFeaturesInvalid1() {
+    assertThrows(IllegalArgumentException.class,
+            () -> extractor.extractIMSFeatures(null, 3, 2));
+  }
+
+  @Test
+  void testExtractFeaturesInvalid2() {
+    assertThrows(IllegalArgumentException.class,
+            () -> extractor.extractIMSFeatures(wtdims, 0, 2));
+  }
+
+  @Test
+  void testExtractFeaturesInvalid3() {
+    assertThrows(IllegalArgumentException.class,
+            () -> extractor.extractIMSFeatures(wtdims, 3, 0));
+  }
+
+  @Test
   void testSerializeFeatures() {
     // prepare
     extractor.extractIMSFeatures(wtdims, 3, 2);
@@ -69,6 +88,25 @@ public class FeaturesExtractorTest extends AbstractDisambiguatorTest {
   }
 
   @Test
+  void testSerializeFeaturesInvalid1() {
+    // prepare
+    extractor.extractIMSFeatures(wtdims, 3, 2);
+    // test
+    assertThrows(IllegalArgumentException.class,
+            () -> extractor.serializeIMSFeatures(
+                    null, extractor.extractTrainingSurroundingWords(List.of(wtdims))));
+  }
+
+  @Test
+  void testSerializeFeaturesInvalid2() {
+    // prepare
+    extractor.extractIMSFeatures(wtdims, 3, 2);
+    // test
+    assertThrows(IllegalArgumentException.class,
+            () -> extractor.serializeIMSFeatures(wtdims, null));
+  }
+
+  @Test
   void testExtractTrainingSurroundingWords() {
     // prepare
     extractor.extractIMSFeatures(wtdims, 3, 2);
@@ -76,5 +114,11 @@ public class FeaturesExtractorTest extends AbstractDisambiguatorTest {
     List<String> surroundingWords = extractor.extractTrainingSurroundingWords(List.of(wtdims));
     assertNotNull(surroundingWords);
     assertEquals(4, surroundingWords.size());
+  }
+
+  @Test
+  void testExtractTrainingSurroundingWordsInvalid1() {
+    assertThrows(IllegalArgumentException.class,
+            () -> extractor.extractTrainingSurroundingWords(null));
   }
 }

--- a/opennlp-wsd/src/test/java/opennlp/tools/disambiguator/LeskEvaluatorIT.java
+++ b/opennlp-wsd/src/test/java/opennlp/tools/disambiguator/LeskEvaluatorIT.java
@@ -45,12 +45,11 @@ class LeskEvaluatorIT extends AbstractEvaluatorTest {
 
   @BeforeEach
   public void setup() {
-    lesk = new Lesk();
     LeskParameters leskParams = new LeskParameters();
     boolean[] a = {true, true, true, true, true, false, false, false, false, false};
     leskParams.setFeatures(a);
     leskParams.setType(LeskParameters.LeskType.LESK_EXT_CTXT);
-    lesk.setParams(leskParams);
+    lesk = new Lesk(leskParams);
   }
 
   @Test

--- a/opennlp-wsd/src/test/java/opennlp/tools/disambiguator/LeskTest.java
+++ b/opennlp-wsd/src/test/java/opennlp/tools/disambiguator/LeskTest.java
@@ -19,19 +19,21 @@
 
 package opennlp.tools.disambiguator;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import opennlp.tools.disambiguator.LeskParameters.LeskType;
-import opennlp.tools.util.Span;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+
+import opennlp.tools.disambiguator.LeskParameters.LeskType;
+import opennlp.tools.util.Span;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * This is the test class for {@link Lesk}.
@@ -56,10 +58,9 @@ class LeskTest extends AbstractDisambiguatorTest {
    */
   @BeforeAll
   static void initEnv() {
-    lesk = new Lesk();
     params = new LeskParameters();
     params.setFeatures(FEATURES);
-    lesk.setParams(params);
+    lesk = new Lesk(params);
   }
 
   @BeforeEach
@@ -110,4 +111,8 @@ class LeskTest extends AbstractDisambiguatorTest {
     assertEquals("WSDHELPER personal pronoun", sensePosSix, "Check preposition");
   }
 
+  @Test
+  void testDisambiguateInvalid() {
+    assertThrows(IllegalArgumentException.class, () -> lesk.disambiguate((WSDSample) null));
+  }
 }

--- a/opennlp-wsd/src/test/java/opennlp/tools/disambiguator/MFSEvaluatorIT.java
+++ b/opennlp-wsd/src/test/java/opennlp/tools/disambiguator/MFSEvaluatorIT.java
@@ -44,7 +44,7 @@ class MFSEvaluatorIT extends AbstractEvaluatorTest {
 
   @BeforeEach
   public void setup() {
-    mfs = new MFS();
+    mfs = new MFS(WSDDefaultParameters.defaultParams());
   }
 
   @Test

--- a/opennlp-wsd/src/test/java/opennlp/tools/disambiguator/MFSTest.java
+++ b/opennlp-wsd/src/test/java/opennlp/tools/disambiguator/MFSTest.java
@@ -29,6 +29,7 @@ import opennlp.tools.util.Span;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -48,7 +49,7 @@ class MFSTest extends AbstractDisambiguatorTest {
    */
   @BeforeAll
   static void setUpAndTraining() {
-    mfs = new MFS();
+    mfs = new MFS(WSDDefaultParameters.defaultParams());
   }
 
   /*
@@ -92,6 +93,11 @@ class MFSTest extends AbstractDisambiguatorTest {
     assertEquals("WSDHELPER personal pronoun", sensePosSix, "Check preposition");
   }
 
+  @Test
+  void testDisambiguateInvalid() {
+    assertThrows(IllegalArgumentException.class, () -> mfs.disambiguate((WSDSample) null));
+  }
+  
   @Test
   void testGetMostFrequentSense() throws InvalidFormatException {
     WSDSample sample = WSDSample.parse("1 The_DT day_NN has_VBZ just_RB started_VBN ._.");

--- a/opennlp-wsd/src/test/java/opennlp/tools/disambiguator/WSDisambiguatorMETest.java
+++ b/opennlp-wsd/src/test/java/opennlp/tools/disambiguator/WSDisambiguatorMETest.java
@@ -37,6 +37,7 @@ import opennlp.tools.util.TrainingParameters;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -139,4 +140,66 @@ class WSDisambiguatorMETest extends AbstractDisambiguatorTest {
     assertEquals("WSDHELPER personal pronoun", sensePosSix, "Check preposition");
   }
 
+  @Test
+  void testDisambiguateInvalid01() {
+    assertThrows(IllegalArgumentException.class, () -> wsdME.disambiguate((WSDSample) null));
+  }
+
+  @Test
+  void testDisambiguateInvalid02() {
+    assertThrows(IllegalArgumentException.class, () -> wsdME.disambiguate(null, tags1, lemmas1));
+  }
+
+  @Test
+  void testDisambiguateInvalid03() {
+    assertThrows(IllegalArgumentException.class, () -> wsdME.disambiguate(sentence1, null, lemmas1));
+  }
+
+  @Test
+  void testDisambiguateInvalid04() {
+    assertThrows(IllegalArgumentException.class, () -> wsdME.disambiguate(sentence1, tags1, null));
+  }
+
+  @Test
+  void testDisambiguateInvalid05() {
+    assertThrows(IllegalArgumentException.class, () -> wsdME.disambiguate(null, tags1, lemmas1, 1));
+  }
+
+  @Test
+  void testDisambiguateInvalid06() {
+    assertThrows(IllegalArgumentException.class, () -> wsdME.disambiguate(sentence1, null, lemmas1, 1));
+  }
+
+  @Test
+  void testDisambiguateInvalid07() {
+    assertThrows(IllegalArgumentException.class, () -> wsdME.disambiguate(sentence1, tags1, null, 1));
+  }
+
+  @Test
+  void testDisambiguateInvalid08() {
+    assertThrows(IllegalArgumentException.class, () -> wsdME.disambiguate(sentence1, tags1, lemmas1, -1));
+  }
+
+  @Test
+  void testDisambiguateInvalid09() {
+    Span span = new Span(3, 7);
+    assertThrows(IllegalArgumentException.class, () -> wsdME.disambiguate(null, tags2, lemmas2, span));
+  }
+
+  @Test
+  void testDisambiguateInvalid10() {
+    Span span = new Span(3, 7);
+    assertThrows(IllegalArgumentException.class, () -> wsdME.disambiguate(sentence2, null, lemmas2, span));
+  }
+
+  @Test
+  void testDisambiguateInvalid11() {
+    Span span = new Span(3, 7);
+    assertThrows(IllegalArgumentException.class, () -> wsdME.disambiguate(sentence2, tags2, null, span));
+  }
+
+  @Test
+  void testDisambiguateInvalid12() {
+    assertThrows(IllegalArgumentException.class, () -> wsdME.disambiguate(sentence2, tags2, lemmas2, null));
+  }
 }


### PR DESCRIPTION
Change
-
- tightens the parameter requirements of `Disambiguator` interface
- tightens the parameter requirements of `FeaturesExtractor` class
- adjusts implementation in related classes
- adds required JUnit tests
- removes `AbstractWSDisambiguator#setParams` method, as it can be done via a constructor allowing a final for this field

Tasks
-
Thank you for contributing to Apache OpenNLP.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn clean install` at the root opennlp-sandbox folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp-sandbox folder?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp-sandbox folder?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions for build issues and submit an update to your PR as soon as possible.
