### PR TITLE
OPENNLP-1738 - Disable WSD test on Linux

### DIFF
--- a/opennlp-wsd/src/test/java/opennlp/tools/disambiguator/WSDisambiguatorMETest.java
+++ b/opennlp-wsd/src/test/java/opennlp/tools/disambiguator/WSDisambiguatorMETest.java
@@ -27,6 +27,8 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.CleanupMode;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -103,6 +105,7 @@ class WSDisambiguatorMETest extends AbstractDisambiguatorTest {
   /*
    * Tests disambiguating only one word : The ambiguous word "please"
    */
+  @DisabledOnOs(value = OS.LINUX, disabledReason = "OPENNLP-1738")
   @Test
   void testDisambiguateOneWord() {
     String sense = wsdME.disambiguate(sentence1, tags1, lemmas1, 8);


### PR DESCRIPTION
as the title says. OPENNLP-1738 has a longer description of the failure, which can be picked up for further investigation.