### PR TITLE
Add explicit permissions for CI and NOTICE regeneration workflows

### DIFF
--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -21,6 +21,10 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,6 +25,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary
- Add explicit `permissions` in `.github/workflows/maven.yml` with `contents: read`.
- Add explicit `permissions` in `.github/workflows/license.yaml` with only required write scopes:
  - `contents: write`
  - `pull-requests: write`

## Why
These workflows currently rely on default token scopes. Declaring permissions explicitly improves least-privilege posture while preserving existing behavior, including automated NOTICE regeneration PRs.