### PR TITLE
Fix broken build in summarizer and opennlp-similarity

### DIFF
--- a/opennlp-similarity/pom.xml
+++ b/opennlp-similarity/pom.xml
@@ -477,7 +477,8 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>-Xmx2048m -Dfile.encoding=UTF-8</argLine>
-          <forkCount>${opennlp.forkCount}</forkCount>
+          <!-- Concurrent JVMs corrupt the shared parse cache. -->
+          <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>
           <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
           <excludes>

--- a/opennlp-similarity/src/main/java/opennlp/tools/textsimilarity/chunker2matcher/ParserCacheSerializer.java
+++ b/opennlp-similarity/src/main/java/opennlp/tools/textsimilarity/chunker2matcher/ParserCacheSerializer.java
@@ -35,11 +35,10 @@ package opennlp.tools.textsimilarity.chunker2matcher;
 
 import java.io.BufferedInputStream;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.lang.invoke.MethodHandles;
@@ -65,6 +64,10 @@ public class ParserCacheSerializer {
   private static final String PARSE_CACHE_FILE_NAME = "sentence_parseObject.dat";
   private static final String PARSE_CACHE_FILE_NAME_CSV = "sentence_parseObject.csv";
 
+  // Written outside the source tree: forked JVMs racing on a tracked file corrupt it.
+  private static final String CACHE_DIR_PROPERTY = "opennlp.similarity.parseCacheDir";
+  private static final String DEFAULT_CACHE_DIR = "target";
+
   public static void writeObject(Object objectToSerialize) {
     if (JAVA_OBJECT_SERIALIZATION) {
       String filename = RESOURCE_DIR + PARSE_CACHE_FILE_NAME;
@@ -79,7 +82,16 @@ public class ParserCacheSerializer {
       Map<String, String[][]> sentence_parseObject = (Map<String, String[][]>) objectToSerialize;
       final List<String> keys = new ArrayList<>(sentence_parseObject.keySet());
 
-      final Path p = Path.of(RESOURCE_DIR + PARSE_CACHE_FILE_NAME_CSV);
+      final Path p = cacheOutputFile();
+      try {
+        final Path dir = p.getParent();
+        if (dir != null) {
+          Files.createDirectories(dir);
+        }
+      } catch (IOException e) {
+        LOG.error("Cannot create parse cache directory for {}: {}", p, e.getMessage());
+        return;
+      }
       try (CSVWriter writer = new CSVWriter(Files.newBufferedWriter(p, StandardCharsets.UTF_8,
               StandardOpenOption.WRITE, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING))) {
         for (String k : keys) {
@@ -110,20 +122,13 @@ public class ParserCacheSerializer {
       }
       return data;
     } else {
-      List<String[]> lines;
-      final String fileName = RESOURCE_DIR + PARSE_CACHE_FILE_NAME_CSV;
-      
-      try (CSVReader reader = new CSVReader(new FileReader(fileName), ',')) {
-        lines = reader.readAll();
-      } catch (FileNotFoundException e) {
-        if (JAVA_OBJECT_SERIALIZATION)
-          LOG.warn("Cannot find cache file");
-        return null;
-      } catch (IOException ioe) {
-        LOG.error(ioe.getMessage(), ioe);
-        return null;
-      }
+      final List<String[]> lines = readCsvLines();
+      // Never null: callers dereference this without a check.
       Map<String, String[][]> sentence_parseObject = new HashMap<>();
+      if (lines == null) {
+        LOG.warn("Cannot find parse cache file {} on the classpath or on disk", PARSE_CACHE_FILE_NAME_CSV);
+        return sentence_parseObject;
+      }
       for (int i = 0; i < lines.size() - 3; i += 4) {
         String key = lines.get(i)[0];
         String[][] value = new String[][] { lines.get(i + 1), lines.get(i + 2),
@@ -132,5 +137,34 @@ public class ParserCacheSerializer {
       }
       return sentence_parseObject;
     }
+  }
+
+  // Classpath copy wins, so the working directory cannot affect the result.
+  private static List<String[]> readCsvLines() {
+    try (InputStream is = ParserCacheSerializer.class.getResourceAsStream("/" + PARSE_CACHE_FILE_NAME_CSV)) {
+      if (is != null) {
+        try (CSVReader reader = new CSVReader(new InputStreamReader(is, StandardCharsets.UTF_8), ',')) {
+          return reader.readAll();
+        }
+      }
+    } catch (IOException ioe) {
+      LOG.error(ioe.getMessage(), ioe);
+    }
+    // Fall back to an earlier run, then the legacy in-tree location.
+    for (Path p : List.of(cacheOutputFile(), Path.of(RESOURCE_DIR + PARSE_CACHE_FILE_NAME_CSV))) {
+      if (!Files.isReadable(p)) {
+        continue;
+      }
+      try (CSVReader reader = new CSVReader(Files.newBufferedReader(p, StandardCharsets.UTF_8), ',')) {
+        return reader.readAll();
+      } catch (IOException ioe) {
+        LOG.error(ioe.getMessage(), ioe);
+      }
+    }
+    return null;
+  }
+
+  private static Path cacheOutputFile() {
+    return Path.of(System.getProperty(CACHE_DIR_PROPERTY, DEFAULT_CACHE_DIR), PARSE_CACHE_FILE_NAME_CSV);
   }
 }

--- a/opennlp-wsd/src/main/java/opennlp/tools/disambiguator/datareader/SemcorReaderExtended.java
+++ b/opennlp-wsd/src/main/java/opennlp/tools/disambiguator/datareader/SemcorReaderExtended.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.io.StringReader;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import javax.xml.XMLConstants;
@@ -305,9 +306,13 @@ public class SemcorReaderExtended {
 
     if (tempFolder.isDirectory()) {
       listOfFiles = tempFolder.listFiles();
-      for (File file : listOfFiles) {
-        List<WSDSample> list = getSemcorOneFileData(directory + file.getName(), wordTag);
-        result.addAll(list);
+      if (listOfFiles != null) {
+        // listFiles() order is filesystem-dependent; sample order fixes the model's word tag.
+        Arrays.sort(listOfFiles);
+        for (File file : listOfFiles) {
+          List<WSDSample> list = getSemcorOneFileData(directory + file.getName(), wordTag);
+          result.addAll(list);
+        }
       }
     }
 

--- a/opennlp-wsd/src/test/java/opennlp/tools/disambiguator/WSDisambiguatorMETest.java
+++ b/opennlp-wsd/src/test/java/opennlp/tools/disambiguator/WSDisambiguatorMETest.java
@@ -100,13 +100,37 @@ class WSDisambiguatorMETest extends AbstractDisambiguatorTest {
     assertNotNull(wsdME, "Checking the disambiguator");
   }
 
-  /*
-   * Tests disambiguating only one word : The ambiguous word "please"
-   */
+  // "We need to discuss an important topic, please write to me soon."
+  // Tags are fixed: the reading of "please" selects the path under test.
+  private static final String[] PLEASE_TOKENS = {
+      "We", "need", "to", "discuss", "an", "important", "topic", ",",
+      "please", "write", "to", "me", "soon", "."};
+  private static final String[] PLEASE_LEMMAS = {
+      "we", "need", "to", "discuss", "a", "important", "topic", ",",
+      "please", "write", "to", "i", "soon", "."};
+  private static final String[] PLEASE_TAGS = {
+      "PRP", "VB", "RP", "VB", "DT", "JJ", "NN", ".",
+      null, "VB", "IN", "PRP", "RB", "."};
+  private static final int PLEASE_INDEX = 8;
+
+  private static String[] pleaseTags(String targetTag) {
+    String[] tags = PLEASE_TAGS.clone();
+    tags[PLEASE_INDEX] = targetTag;
+    return tags;
+  }
+
+  // "please.r" does not match the trained "please.v": exercises the WordNet fallback.
   @Test
-  void testDisambiguateOneWord() {
-    String sense = wsdME.disambiguate(sentence1, tags1, lemmas1, 8);
+  void testDisambiguateOneWordAsAdverb() {
+    String sense = wsdME.disambiguate(PLEASE_TOKENS, pleaseTags("UH"), PLEASE_LEMMAS, PLEASE_INDEX);
     assertEquals("WORDNET please%4:02:00::", sense, "Check 'please' sense ID");
+  }
+
+  // "please.v" matches the trained model: exercises the maxent model.
+  @Test
+  void testDisambiguateOneWordAsVerb() {
+    String sense = wsdME.disambiguate(PLEASE_TOKENS, pleaseTags("VB"), PLEASE_LEMMAS, PLEASE_INDEX);
+    assertEquals("WORDNET please%2:37:00::", sense, "Check 'please' sense ID");
   }
 
   /*

--- a/summarizer/pom.xml
+++ b/summarizer/pom.xml
@@ -35,14 +35,6 @@
     
     <maven.download.plugin>1.13.0</maven.download.plugin>
   </properties>
-  <repositories>
-    <repository>
-      <id>maven.aksw.org</id>
-      <url>https://maven.aksw.org/repository/internal/</url>
-      <releases/>
-    </repository>
-  </repositories>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.opennlp</groupId>
@@ -69,7 +61,7 @@
     <!-- End model resources -->
 
     <dependency>
-      <groupId>edu.mit</groupId>
+      <groupId>io.github.x-englishwordnet</groupId>
       <artifactId>jwi</artifactId>
       <version>${wordnet.version}</version>
     </dependency>


### PR DESCRIPTION
Fixing the sandbox build.

* Replace edu.mit:jwi with the Maven Central republish - maven.aksw.org is offline and was the only source.
* Stop writing the parse cache into src/test/resources and pin the module to one fork. Concurrent JVMs were corrupting the tracked CSV.
* Split WSD one-word test into fallback and maxent paths.
